### PR TITLE
Synchronous stop

### DIFF
--- a/lib/thinking_sphinx/tasks.rb
+++ b/lib/thinking_sphinx/tasks.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'timeout'
 
 namespace :thinking_sphinx do
   task :app_env do
@@ -52,6 +53,12 @@ namespace :thinking_sphinx do
       config = ThinkingSphinx::Configuration.instance
       pid    = sphinx_pid
       config.controller.stop
+      
+      # Ensure searchd is stopped, but don't try too hard
+      Timeout.timeout(5) do
+        sleep(1) until config.controller.stop
+      end
+      
       puts "Stopped search daemon (pid #{pid})."
     end
   end


### PR DESCRIPTION
Added a sleep/check loop to ensure that `searchd` is stopped in the `thinking_sphinx:stop` task since it doesn't always stop on the first try.

We timeout after 5 seconds if it still hasn't shut down. This raises a timeout error in the same task that should be informative to someone experiencing this error.
