### PR TITLE
Use ActiveSupport.on_load(:active_record)

### DIFF
--- a/lib/thinking_sphinx/railtie.rb
+++ b/lib/thinking_sphinx/railtie.rb
@@ -5,8 +5,8 @@ module ThinkingSphinx
   class Railtie < Rails::Railtie
 
     initializer "thinking_sphinx.active_record" do
-      if defined?(ActiveRecord)
-        ::ActiveRecord::Base.send(:include, ThinkingSphinx::ActiveRecord)
+      ActiveSupport.on_load :active_record do
+        include ThinkingSphinx::ActiveRecord
       end
     end
 


### PR DESCRIPTION
Adding thinking-sphinx to the Gemfile triggers active_record to be loaded before it is needed. It should do the opposite, where it is not loaded until active_record is loaded.

This change will make the server start faster and non active_record related tests start faster when run individually.

I've been trying to avoid gems that cause this problem, but yours is too good to pass up ;)
