### PR TITLE
Added the necessary code to Thinking Sphinx works with Octopus.

### DIFF
--- a/lib/thinking_sphinx/adapters/abstract_adapter.rb
+++ b/lib/thinking_sphinx/adapters/abstract_adapter.rb
@@ -26,6 +26,14 @@ module ThinkingSphinx
         else
           raise "Invalid Database Adapter: Sphinx only supports MySQL and PostgreSQL"
         end
+      when "Octopus::Proxy"
+        if %w(mysql mysql2).include?(model.connection.config[:adapter])
+          ThinkingSphinx::MysqlAdapter.new model
+        elsif model.connection.config[:adapter] == "postgresql"
+          ThinkingSphinx::PostgreSQLAdapter.new model
+        else
+          raise "Invalid Database Adapter: Sphinx only supports MySQL and PostgreSQL"
+        end
       else
         raise "Invalid Database Adapter: Sphinx only supports MySQL and PostgreSQL, not #{model.connection.class.name}"
       end


### PR DESCRIPTION
Hi, Octopus was a Ruby Summer of Code project. It's currently the best option for data replication using Rails.

We want to make it works with Thinking Sphinx, but we need to make your project recognizes an Octopus object. If you can add this code in your project we would be very grateful!

Reference:
Ruby Summer of Code Project #16: ActiveRecord Sharding (http://rubysoc.org/projects)

Octopus:
http://github.com/tchandy/octopus
