### PR TITLE
Excerpt options

### DIFF
--- a/features/excerpts.feature
+++ b/features/excerpts.feature
@@ -11,3 +11,11 @@ Feature: Generate excerpts for search results
     And I am searching on comments
     And I search for "lorem"
     Then calling content on the first result excerpts object should return "de un sitio mientras que mira su diseño. El punto de usar <span class="match">Lorem</span> Ipsum es que tiene una distribución"
+
+  Scenario: Excerpt Options
+    Given Sphinx is running
+    And I am searching on comments
+    And I search for "lorem"
+    And I provide excerpt option "before_match" with value "<em>"
+    And I provide excerpt option "after_match" with value "</em>"
+    Then calling content on the first result excerpts object should return "de un sitio mientras que mira su diseño. El punto de usar <em>Lorem</em> Ipsum es que tiene una distribución"

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -87,3 +87,8 @@ end
 Then /^the first result should have a (\w+\s?\w*) of (\d+)$/ do |attribute, value|
   results.first.sphinx_attributes[attribute.gsub(/\s+/, '_')].should == value.to_i
 end
+
+Given /^I provide excerpt option "([a-z_]*)" with value "([^"]*)"$/ do |k, v|
+  @options[:excerpt_options] ||= {}
+  @options[:excerpt_options][k.to_sym] = v
+end

--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -272,9 +272,11 @@ module ThinkingSphinx
       
       populate
       client.excerpts(
-        :docs   => [string],
-        :words  => results[:words].keys.join(' '),
-        :index  => options[:index] || "#{model.source_of_sphinx_index.sphinx_name}_core"
+        {
+          :docs   => [string],
+          :words  => results[:words].keys.join(' '),
+          :index  => options[:index] || "#{model.source_of_sphinx_index.sphinx_name}_core"
+        }.merge(options[:excerpt_options] || {})
       ).first
     end
     


### PR DESCRIPTION
I wanted to be able to use the excerpt options (as detailed in the comment for Riddle::Client#excerpts) on ThinkingSphinx searches. These options are passed in using a new search option, :excerpt_options. To wit:

  MyModel.search "foo", :excerpt_options => { :chunk_separator => "+++" }

Perhaps this would be of use to others? In any case, thanks for the great libraries.
