### PR TITLE
"SET TIME ZONE UTC" under Postgres 8.1.18

### DIFF
--- a/lib/thinking_sphinx/adapters/postgresql_adapter.rb
+++ b/lib/thinking_sphinx/adapters/postgresql_adapter.rb
@@ -68,7 +68,7 @@ module ThinkingSphinx
     end
     
     def utc_query_pre
-      'SET TIME ZONE UTC'
+      "SET TIME ZONE 'UTC'"
     end
     
     private


### PR DESCRIPTION
For some strange reason, "SET TIME ZONE UTC" fails under Postgres 8.1.18 with the following message:

ERROR: index 'location_core': sql_query_pre[0]: ERROR:  unrecognized time zone name: "utc"

After some investigation, I found that if I added single quotes around the 'UTC' it worked! I couldn't find any documentation around this issue. I looked in Rails (because I know they set a similar thing) and they use single quotes as well.
