### PR TITLE
Option to specify the user for thinking sphinx

### DIFF
--- a/lib/thinking_sphinx/deploy/capistrano.rb
+++ b/lib/thinking_sphinx/deploy/capistrano.rb
@@ -92,8 +92,10 @@ DESC
     def rake(*tasks)
       rails_env = fetch(:rails_env, "production")
       rake = fetch(:rake, "rake")
+      user = fetch(:thinking_sphinx_user, nil)
+      sudo = user.nil? ? "" : "sudo -u #{user} -p \"Password for #{user} for Thinking Sphinx: \""
       tasks.each do |t|
-        run "if [ -d #{release_path} ]; then cd #{release_path}; else cd #{current_path}; fi; #{rake} RAILS_ENV=#{rails_env} #{t}"
+        run "if [ -d #{release_path} ]; then cd #{release_path}; else cd #{current_path}; fi; #{sudo} #{rake} RAILS_ENV=#{rails_env} #{t}"
       end
     end
   end


### PR DESCRIPTION
We are currently deploying as root, but we do need to run thinking sphinx tasks as www-data, so I've added an option to the capistrano tasks to allow for that. Basically you configure it like this:

```
set :thinking_sphinx_user, "www-data"
```

If you don't like the name of the option or the prompt for sudo, I can change them, just let me know.
