### PR TITLE
Fix indexing of has_many associations specified using hash of conditions

### DIFF
--- a/lib/thinking_sphinx/association.rb
+++ b/lib/thinking_sphinx/association.rb
@@ -67,7 +67,7 @@ module ThinkingSphinx
       arel_join = @join.with_join_class(Arel::OuterJoin)
       arel_join.options[:conditions].gsub!(/::ts_join_alias::/,
         "#{@reflection.klass.connection.quote_table_name(@join.parent.aliased_table_name)}"
-      ) unless arel_join.options[:conditions].nil?
+      ) unless arel_join.options[:conditions].nil? || arel_join.options[:conditions].is_a?(String)
       
       arel_join
     end


### PR DESCRIPTION
This fix just makes part of the job because polymorphic associations are not covered by it.

But it allows working with much more common case of associations like:
in model:

has_many :birth_dates, :class_name => 'AlternativeDate', :conditions => { :kind => :birth }
has_many :death_dates, :class_name => 'AlternativeDate', :conditions => { :kind => :death }

define_index do
...
      indexes birth_dates(:year), :as => "birth_year".to_sym
      indexes death_dates(:year), :as => "death_year".to_sym
...
end

Without the fix i cannot specify such relations in model.
And in my case i have no workaround to set conditions using string.
