### PR TITLE
Do not add method_missing when not needed to has_many_association

### DIFF
--- a/lib/thinking_sphinx/active_record.rb
+++ b/lib/thinking_sphinx/active_record.rb
@@ -1,6 +1,7 @@
 require 'thinking_sphinx/active_record/attribute_updates'
 require 'thinking_sphinx/active_record/delta'
 require 'thinking_sphinx/active_record/has_many_association'
+require 'thinking_sphinx/active_record/has_many_association_with_scopes'
 require 'thinking_sphinx/active_record/scopes'
 
 module ThinkingSphinx

--- a/lib/thinking_sphinx/active_record/has_many_association.rb
+++ b/lib/thinking_sphinx/active_record/has_many_association.rb
@@ -9,17 +9,7 @@ module ThinkingSphinx
         args << options
         @reflection.klass.search(*args)
       end
-      
-      def method_missing(method, *args, &block)
-        if responds_to_scope(method)
-          @reflection.klass.
-            search(:with => default_filter).
-            send(method, *args, &block)
-        else
-          super
-        end
-      end
-      
+
       private
       
       def attribute_for_foreign_key
@@ -40,11 +30,6 @@ module ThinkingSphinx
       
       def default_filter
         {attribute_for_foreign_key.unique_name => @owner.id}
-      end
-      
-      def responds_to_scope(scope)
-        @reflection.klass.respond_to?(:sphinx_scopes)   &&
-        @reflection.klass.sphinx_scopes.include?(scope)
       end
     end
   end

--- a/lib/thinking_sphinx/active_record/has_many_association_with_scopes.rb
+++ b/lib/thinking_sphinx/active_record/has_many_association_with_scopes.rb
@@ -1,0 +1,21 @@
+module ThinkingSphinx
+  module ActiveRecord
+    module HasManyAssociationWithScopes
+      def method_missing(method, *args, &block)
+        if responds_to_scope(method)
+          @reflection.klass.
+            search(:with => default_filter).
+            send(method, *args, &block)
+        else
+          super
+        end
+      end
+      
+      private
+      def responds_to_scope(scope)
+        @reflection.klass.respond_to?(:sphinx_scopes)   &&
+        @reflection.klass.sphinx_scopes.include?(scope)
+      end
+    end
+  end
+end

--- a/lib/thinking_sphinx/active_record/scopes.rb
+++ b/lib/thinking_sphinx/active_record/scopes.rb
@@ -17,6 +17,7 @@ module ThinkingSphinx
         # The scope is automatically applied when the search method is called. It
         # will only be applied if it is an existing sphinx_scope.
         def default_sphinx_scope(sphinx_scope_name)
+          add_sphinx_scopes_support_to_has_many_associations
           @default_sphinx_scope = sphinx_scope_name
         end
 
@@ -43,6 +44,8 @@ module ThinkingSphinx
         #   @articles =  Article.latest_first.search 'pancakes'
         #
         def sphinx_scope(method, &block)
+          add_sphinx_scopes_support_to_has_many_associations
+
           @sphinx_scopes ||= []
           @sphinx_scopes << method
           
@@ -76,6 +79,14 @@ module ThinkingSphinx
           
           sphinx_scopes.clear
         end
+
+        def add_sphinx_scopes_support_to_has_many_associations
+          scope_mixin = ::ThinkingSphinx::ActiveRecord::HasManyAssociationWithScopes
+
+          ::ActiveRecord::Associations::HasManyAssociation.send(:include, scope_mixin)
+          ::ActiveRecord::Associations::HasManyThroughAssociation.send(:include, scope_mixin)
+        end
+
       end
     end
   end

--- a/thinking-sphinx.gemspec
+++ b/thinking-sphinx.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
     "lib/thinking_sphinx/active_record/attribute_updates.rb",
     "lib/thinking_sphinx/active_record/delta.rb",
     "lib/thinking_sphinx/active_record/has_many_association.rb",
+    "lib/thinking_sphinx/active_record/has_many_association_with_scopes.rb",
     "lib/thinking_sphinx/active_record/scopes.rb",
     "lib/thinking_sphinx/adapters/abstract_adapter.rb",
     "lib/thinking_sphinx/adapters/mysql_adapter.rb",


### PR DESCRIPTION
Hello Pat,

  As per my message at http://groups.google.com/group/thinking-sphinx/browse_thread/thread/20277162df56d5fe , here is a patch with prevents adding method_missing to has_many associations. 

  I was really wrong with my measurements of performance - this patch adds only 3-5% of performance in my tests. I should have monitored CPU temperature better when testing performance.

  I don't check that the module is already included, because, it looks like a module is always included only once into other one - so there is no need to check this. 

  Best regards,
  KIR
