### PR TITLE
add option only

### DIFF
--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -916,7 +916,7 @@ module ThinkingSphinx
     end
 
     def scoped_count
-      return self.total_entries if @options[:ids_only]
+      return self.total_entries if(@options[:ids_only] || @options[:only])
 
       @options[:ids_only] = true
       results_count = self.total_entries


### PR DESCRIPTION
Hi Pat,

due to performance reasons i want to avoid the activerecord instantiation and therefor added the option 'only' which works similar to ids_only. The difference is that you can specify other fields than id. 

Article.search(:conditions => {:subject => 'pancakes'}, :only => "subject")
=> ['pankakes']

Article.search(:conditions => {:subject => 'pancakes'},:only => ["subject", "created_at"])
=> {'subject => ''pankakes', 'created_at' => '2011-01-27 10:00:00'}

Perhaps this could be useful for others, too.

Cheers,
Hans
