### PR TITLE
excerpts were failing when non-default index existed 

### DIFF
--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -309,7 +309,7 @@ module ThinkingSphinx
         {
           :docs   => [string.to_s],
           :words  => results[:words].keys.join(' '),
-          :index  => options[:index] || "#{model.source_of_sphinx_index.sphinx_name}_core"
+          :index  => options[:index] || "#{model.core_index_names.first}"
         }.merge(options[:excerpt_options] || {})
       ).first
     end


### PR DESCRIPTION
Hi Pat,

I started using thinking sphinx after I met you at rails camp margate (i was using ultrasphinx before) and I'm happy to send my first pull request :)

I was creating some indexes by name for a model called "Place" so I didn't have any "place_code" index. Indexing and searching were fine, but when trying to use the excerpts, I got the following error 

Error (searchd error (status: 1): unknown local index 'place_core' in search request)

After a bit of research, I saw you are trying to use the "model_core" index by default unless an specific index is selected at search time. I changed the behaviour so now it uses model.core_index_names.first. This way, the index is using for excerpts is always a valid one.

I'm copying below an extract of the code I was using to generate my indices when I got the error. After the fix, everything is working fine

 [ 'libstemmer_en', 'libstemmer_es' ].each do |stemmer|  
    define_index "place#{stemmer}" do
      indexes name, :sortable => true
      indexes description
      indexes specialties
      indexes address

```
  has created_at
  has "RADIANS(latitude)",  :as => :latitude,  :type => :float
  has "RADIANS(longitude)", :as => :longitude, :type => :float

  set_property :morphology => stemmer 
end  
```
