### PR TITLE
Clarified unsupported sphinx version error message

### DIFF
--- a/lib/thinking_sphinx/auto_version.rb
+++ b/lib/thinking_sphinx/auto_version.rb
@@ -8,19 +8,28 @@ module ThinkingSphinx
       when '1.10-beta', '1.10-id64-beta', '1.10-dev'
         require 'riddle/1.10'
       else
-        unless version.nil? or version.empty?
-          STDERR.puts "Unsupported version: #{version}"
-        end
-        STDERR.puts %Q{
+        documentation_link = %Q{
+For more information, read the documentation:
+http://freelancing-god.github.com/ts/en/advanced_config.html          
+}
+
+        if version.nil? || version.empty?
+          STDERR.puts %Q{
 Sphinx cannot be found on your system. You may need to configure the following
 settings in your config/sphinx.yml file:
   * bin_path
   * searchd_binary_name
   * indexer_binary_name
 
-For more information, read the documentation:
-http://freelancing-god.github.com/ts/en/advanced_config.html
+#{documentation_link}
 }
+        else
+          STDERR.puts %Q{
+Unsupported version: #{version}
+
+#{documentation_link}
+}
+        end
       end
     end
   end

--- a/spec/thinking_sphinx/auto_version_spec.rb
+++ b/spec/thinking_sphinx/auto_version_spec.rb
@@ -38,15 +38,15 @@ describe ThinkingSphinx::AutoVersion do
       ThinkingSphinx::AutoVersion.detect
     end
     
-    it "should output a warning if the detected version is something else" do
-      STDERR.should_receive(:puts).twice
+    it "should output a warning if the detected version is unsupported" do
+      STDERR.should_receive(:puts).with(/unsupported/i)
       
       @config.stub!(:version => '0.9.7')
       ThinkingSphinx::AutoVersion.detect
     end
     
     it "should output a warning if the version cannot be determined" do
-      STDERR.should_receive(:puts)
+      STDERR.should_receive(:puts).at_least(:once)
       
       @config.stub!(:version => nil)
       ThinkingSphinx::AutoVersion.detect


### PR DESCRIPTION
Just a minor change to the error message thinking-sphinx spits out when an unsupported sphinx version is detected.  Now have separate error messages for not supported vs not found.
