### PR TITLE
Prefer sanitize_sql_for_conditions to the deprecated sanitize_sql

### DIFF
--- a/lib/thinking_sphinx/index/builder.rb
+++ b/lib/thinking_sphinx/index/builder.rb
@@ -252,15 +252,17 @@ module ThinkingSphinx
       end
       
       # Use this method to generate SQL for your attributes, conditions, etc.
-      # You can pass in as whatever ActiveRecord::Base.sanitize_sql accepts.
+      # You can pass in whatever
+      # ActiveRecord::Base.sanitize_sql_for_conditions accepts.
       # 
-      #   where sanitize_sql(["active = ?", true])
+      #   where sanitize_sql_for_conditions(:active => true)
       #   #=> WHERE active = 1
       # 
-      def sanitize_sql(*args)
-        @index.model.send(:sanitize_sql, *args)
+      def sanitize_sql_for_conditions(condition)
+        @index.model.send(:sanitize_sql_for_conditions, condition)
       end
-      
+      alias_method :sanitize_sql, :sanitize_sql_for_conditions
+
       private
       
       def source

--- a/spec/thinking_sphinx/index/builder_spec.rb
+++ b/spec/thinking_sphinx/index/builder_spec.rb
@@ -493,16 +493,16 @@ describe ThinkingSphinx::Index::Builder do
     end
   end
   
-  describe "sanitize_sql" do
+  describe "sanitize_sql_for_conditions" do
     def index
       @index ||= ThinkingSphinx::Index::Builder.generate(Person) do
         indexes first_name, last_name
-        where sanitize_sql(["gender = ?", "female"])
+        where sanitize_sql_for_conditions(:gender => "female")
       end
     end
     
-    it "should be aliased to ActiveRecord::Base.sanitize_sql" do
-      index.sources.first.conditions.first.should == index.model.send(:sanitize_sql, ["gender = ?", "female"])
+    it "should be aliased to ActiveRecord::Base.sanitize_sql_for_conditions" do
+      index.sources.first.conditions.first.should == index.model.send(:sanitize_sql_for_conditions, {:gender => "female"})
     end
   end
 end


### PR DESCRIPTION
# sanitize_sql is aliased to #sanitize_sql_for_conditions for backwards compatibility.
