### PR TITLE
Add mysql2 adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'riddle',       '>= 1.3.3'
 
 group :development do
   gem 'mysql',              '2.8.1'
+  gem 'mysql2',             '0.2.7'
   gem 'pg',                 '0.9.0'
   gem 'actionpack',         '>= 3.0.3'
   gem 'jeweler',            '1.5.1'

--- a/lib/thinking_sphinx.rb
+++ b/lib/thinking_sphinx.rb
@@ -292,6 +292,7 @@ module ThinkingSphinx
 
   def self.mysql?
     ::ActiveRecord::Base.connection.class.name.demodulize == "MysqlAdapter" ||
+    ::ActiveRecord::Base.connection.class.name.demodulize == "Mysql2Adapter" ||
     ::ActiveRecord::Base.connection.class.name.demodulize == "MysqlplusAdapter" || (
       jruby? && ::ActiveRecord::Base.connection.config[:adapter] == "jdbcmysql"
     )

--- a/spec/sphinx_helper.rb
+++ b/spec/sphinx_helper.rb
@@ -1,6 +1,8 @@
 require 'active_record'
 prefix = defined?(JRUBY_VERSION) ? "jdbc" : ""
 require "active_record/connection_adapters/#{prefix}mysql_adapter"
+require "active_record/connection_adapters/mysql2_adapter"
+
 begin
   require "active_record/connection_adapters/#{prefix}postgresql_adapter"
 rescue LoadError

--- a/spec/thinking_sphinx_spec.rb
+++ b/spec/thinking_sphinx_spec.rb
@@ -151,6 +151,15 @@ describe ThinkingSphinx do
       
       ThinkingSphinx.use_group_by_shortcut?.should be_true
     end
+
+    it "should return true if using mysql2 gem" do
+      @connection.stub!(
+        :class => ActiveRecord::ConnectionAdapters::Mysql2Adapter,
+        :select_all => {:a => ""}
+      )
+
+      ThinkingSphinx.use_group_by_shortcut?.should be_true
+    end
   
     it "should return false if ONLY_FULL_GROUP_BY is set" do
       @connection.stub!(


### PR DESCRIPTION
Rails 3 default is to use mysql2 gem however it's not in the list of adapters for which `use_group_by_shortcut?` is true leading to greatly increased indexing times (in the order of a hundred times slower for my app).
