### PR TITLE
Add `touched_reindex_file` option

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -53,7 +53,7 @@ module ThinkingSphinx
     CustomOptions = %w( disable_range use_64_bit )
     
     attr_accessor :searchd_file_path, :allow_star, :database_yml_file,
-      :app_root, :model_directories, :delayed_job_priority, :indexed_models, :use_64_bit
+      :app_root, :model_directories, :delayed_job_priority, :indexed_models, :use_64_bit, :touched_reindex_file
     
     attr_accessor :source_options, :index_options
     attr_accessor :version

--- a/lib/thinking_sphinx/tasks.rb
+++ b/lib/thinking_sphinx/tasks.rb
@@ -86,7 +86,9 @@ namespace :thinking_sphinx do
   task :reindex => :app_env do
     config = ThinkingSphinx::Configuration.instance
     FileUtils.mkdir_p config.searchd_file_path
-    puts config.controller.index
+    output = config.controller.index
+    puts output
+    FileUtils.touch config.touched_reindex_file if config.touched_reindex_file and output =~ /succesfully sent SIGHUP to searchd/
   end
   
   desc "Stop Sphinx (if it's running), rebuild the indexes, and start Sphinx"


### PR DESCRIPTION
After calling `rake ts:reindex`, Thinking Sphinx will “touch” a specific file if the indices are succesfully rotated. 

This makes it easy to monitor Sphinx and Thinking Sphinx and to make sure they are are running properly on a server by verifying that the file timestamp is up-to-date with one’s `rake ts:reindex` cronjob.

I don’t know if you think this is an interesting feature (I do!) so I didn’t write any specs for the feature. If you agree that this is something Thinking Sphinx could use, I'm willing to make the feature more complete and TS-worthy.

Thanks!
