### PR TITLE
Add a “touched_reindex_file” option to sphinx.yml

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -54,7 +54,7 @@ module ThinkingSphinx
     CustomOptions = %w( disable_range use_64_bit )
     
     attr_accessor :searchd_file_path, :allow_star, :database_yml_file,
-      :app_root, :model_directories, :delayed_job_priority, :indexed_models, :use_64_bit
+      :app_root, :model_directories, :delayed_job_priority, :indexed_models, :use_64_bit, :touched_reindex_file
     
     attr_accessor :source_options, :index_options
     attr_accessor :version
@@ -258,7 +258,12 @@ module ThinkingSphinx
         end
       end
     end
-    
+
+    def touch_reindex_file(output)
+      return FileUtils.touch(@touched_reindex_file) if @touched_reindex_file and output =~ /succesfully sent SIGHUP to searchd/
+      false
+    end
+
     private
     
     # Parse the config/sphinx.yml file - if it exists - then use the attribute

--- a/lib/thinking_sphinx/tasks.rb
+++ b/lib/thinking_sphinx/tasks.rb
@@ -90,7 +90,9 @@ namespace :thinking_sphinx do
   task :reindex => :app_env do
     config = ThinkingSphinx::Configuration.instance
     FileUtils.mkdir_p config.searchd_file_path
-    puts config.controller.index
+    output = config.controller.index
+    puts output
+    config.touch_reindex_file(output)
   end
   
   desc "Stop Sphinx (if it's running), rebuild the indexes, and start Sphinx"


### PR DESCRIPTION
After calling rake ts:reindex, ThinkingSphinx will “touch” a specific file if the indices are succesfully rotated. This makes it easier to monitor that Sphinx and ThinkingSphinx are running properly on a server by verifying that the file timestamp is up-to-date with your `rake ts:reindex` cronjob.

I made the commit in the `master` branch, as requested :)
