### PR TITLE
Also check if the attribute alias matches the foreign key (master)

### DIFF
--- a/lib/thinking_sphinx/active_record/has_many_association.rb
+++ b/lib/thinking_sphinx/active_record/has_many_association.rb
@@ -20,7 +20,8 @@ module ThinkingSphinx
         (@reflection.klass.sphinx_indexes || []).each do |index|
           attribute = index.attributes.detect { |attrib|
             attrib.columns.length == 1 &&
-            attrib.columns.first.__name  == foreign_key.to_sym
+            attrib.columns.first.__name  == foreign_key.to_sym ||
+            attrib.alias == foreign_key.to_sym
           }
           return attribute unless attribute.nil?
         end

--- a/spec/fixtures/models.rb
+++ b/spec/fixtures/models.rb
@@ -6,9 +6,12 @@ end
 
 class FootballTeam < ActiveRecord::Base
   has_many :tags
+  has_many :people, :through => :tags
 end
 
 class CricketTeam < ActiveRecord::Base
+  has_many :people, :foreign_key => :team_id
+
   define_index do
     indexes :name
     has "SELECT cricket_team_id, id FROM tags", :source => :query, :as => :tags
@@ -65,6 +68,7 @@ class Person < ActiveRecord::Base
     
     has [:id, :team_id], :as => :ids
     has team(:id), :as => :team_id
+    has football_teams(:id), :as => :football_team_id
     
     has contacts.phone_number, :as => :phone_number_sort
     has contacts(:id), :as => :contact_ids

--- a/spec/thinking_sphinx/active_record/has_many_association_spec.rb
+++ b/spec/thinking_sphinx/active_record/has_many_association_spec.rb
@@ -23,6 +23,17 @@ describe 'ThinkingSphinx::ActiveRecord::HasManyAssociation' do
       @person.friendships.search "test"
     end
     
+    it "should add a filter for an aliased attribute into a normal search call" do
+      @team = CricketTeam.new
+      @team.stub!(:id => 1)
+
+      Person.should_receive(:search).with do |query, options|
+        options[:with][:team_id].should == @team.id
+      end
+
+      @team.people.search "test"
+    end
+
     it "should define indexes for the reflection class" do
       Friendship.should_receive(:define_indexes)
       
@@ -50,6 +61,17 @@ describe 'ThinkingSphinx::ActiveRecord::HasManyAssociation' do
       end
       
       @person.friends.search "test"
+    end
+
+    it "should add a filter for an aliased attribute into a normal search call" do
+      @team = FootballTeam.new
+      @team.stub!(:id => 1)
+
+      Person.should_receive(:search).with do |query, options|
+        options[:with][:football_team_id].should == @team.id
+      end
+
+      @team.people.search "test"
     end
   end
   


### PR DESCRIPTION
Given models like this:

``` ruby
class Category < ActiveRecord::Base
  has_many :category_products
  has_many :products, :through => :category_products
end

class CategoryProduct < ActiveRecord::Base
  belongs_to :category
  belongs_to :product
end

class Product < ActiveRecord
  has_many :category_products
  has_many :categories, :through => :category_products

  define_index do
    indexes name
    has categories(:id), :as => :category_id
  end
end
```

then executing the following query results in an error:

``` ruby
>> category.products.search "test"
RuntimeError: Missing Attribute for Foreign Key category_id
```

This can be worked around by using `has category_products(:category_id)` but the error can be hard to track down as an attribute with that name is defined. This pull request fixes the bug by checking the attribute's alias to see if it matches the foreign key. It's checked after the attribute's columns are checked to ensure backwards compatibility.
