### PR TITLE
Add a shuffle option to configurations to shuffle servers before handing them off to Riddle.

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -64,7 +64,7 @@ module ThinkingSphinx
     
     attr_accessor :searchd_file_path, :allow_star, :app_root,
       :model_directories, :delayed_job_priority, :indexed_models, :use_64_bit,
-      :touched_reindex_file, :stop_timeout, :version
+      :touched_reindex_file, :stop_timeout, :version, :shuffle
     
     attr_accessor :source_options, :index_options
     
@@ -111,6 +111,7 @@ module ThinkingSphinx
         Dir.glob("#{app_root}/vendor/plugins/*/app/models/")
       self.delayed_job_priority = 0
       self.indexed_models       = []
+      self.shuffle              = true
       
       self.source_options  = {}
       self.index_options   = {
@@ -249,7 +250,13 @@ module ThinkingSphinx
     attr_accessor :timeout
 
     def client
-      client = Riddle::Client.new address, port,
+      addresses = if shuffle && address.is_a?(Array)
+        address.respond_to?(:shuffle) ? address.shuffle : address.sort_by{ rand }
+      else
+        address
+      end
+
+      client = Riddle::Client.new addresses, port,
         configuration.searchd.client_key
       client.max_matches = configuration.searchd.max_matches || 1000
       client.timeout = timeout || 0

--- a/spec/thinking_sphinx/configuration_spec.rb
+++ b/spec/thinking_sphinx/configuration_spec.rb
@@ -276,6 +276,32 @@ describe ThinkingSphinx::Configuration do
     it "should use the configuration timeout" do
       @config.client.timeout.should == 1
     end
+
+    describe 'when shuffle is enabled' do
+      before :each do
+        @config.shuffle = true
+      end
+
+      it "should shuffle client servers" do
+        @config.should_receive(:shuffle).and_return(['2.2.2.2', '1.1.1.1'])
+
+        @config.address = ['1.1.1.1', '2.2.2.2']
+
+        @config.client.servers.should == ['2.2.2.2', '1.1.1.1']
+      end
+    end
+
+    describe 'when shuffle is disabled' do
+      before :each do
+        @config.shuffle = false
+      end
+
+      it "should not shuffle client servers" do
+        @config.address = ['1.1.1.1', '2.2.2.2.', '3.3.3.3', '4.4.4.4', '5.5.5.5']
+
+        @config.client.servers.should == @config.address
+      end
+    end
   end
   
   describe '#models_by_crc' do


### PR DESCRIPTION
Added shuffle option to configurations (defaults to true).  When enabled, addresses will be shuffled before giving them to the Riddle client.
