### PR TITLE
Don't suppress LoadError and NameError when loading models.

### DIFF
--- a/lib/thinking_sphinx/context.rb
+++ b/lib/thinking_sphinx/context.rb
@@ -62,7 +62,7 @@ class ThinkingSphinx::Context
         
         begin
           camelized_model.constantize
-        rescue StandardError => err
+        rescue Error => err
           STDERR.puts "Warning: Error loading #{file}:"
           STDERR.puts err.message
           STDERR.puts err.backtrace.join("\n"), ''


### PR DESCRIPTION
I spent a couple of hours trying to figure out an issue I was having (which was ultimately my and my text editor's fault) which could have been easily solved by having had Context#load_models not rescue a LoadError raised by Rails ("Expected #{path} to defined #{model}").

See here for more info: http://stackoverflow.com/questions/7262925/ruby-rails-class-loading-weirdness-possibly-thinking-sphinx-related/7272770#7272770
