### PR TITLE
Fix for acts-as-taggable-on with rails 3.1

### DIFF
--- a/lib/thinking_sphinx/association.rb
+++ b/lib/thinking_sphinx/association.rb
@@ -214,6 +214,7 @@ module ThinkingSphinx
       if defined?(ActsAsTaggableOn) &&
         @reflection.klass == ActsAsTaggableOn::Tagging &&
         @reflection.name.to_s[/_taggings$/]
+        condition.gsub! /taggings\.tag_id = tags\.id AND/, "" if ThinkingSphinx.rails_3_1?
         condition = condition.gsub /taggings\./, "#{quoted_alias @join}."
       end
       


### PR DESCRIPTION
Fixes an issue with the sql query left our join on condition when using rails 3.1. Without this fix the generated sphinx conf will error out when you try and index because the sql query has an error with the left outer joins conditions for acts-as-taggable-on associations that are to be indexed.

Before:
LEFT OUTER JOIN `taggings` ON `tags`.`id` = `taggings`.`tag_id` AND `taggings`.`taggable_id` = `posts`.`id` AND  `taggings`.context = 'tags' AND `taggings`.`taggable_type` = 'Post'

the `tags`.`id` = `taggings`.`tag_id` condition will throw an error.

After:
LEFT OUTER JOIN `taggings` ON `taggings`.`taggable_id` = `posts`.`id` AND  `taggings`.context = 'tags' AND `taggings`.`taggable_type` = 'Post'

Just a simple gsub! to remove the condition in the rewrite_condition method.
