### PR TITLE
Suggested extra warning regarding ts:index

### DIFF
--- a/lib/thinking_sphinx/tasks.rb
+++ b/lib/thinking_sphinx/tasks.rb
@@ -51,6 +51,7 @@ namespace :thinking_sphinx do
         puts "Started successfully (pid #{sphinx_pid})."
       else
         puts "Failed to start searchd daemon. Check #{config.searchd_log_file}"
+        puts "Be sure to run thinking_sphinx:index before thinking_sphinx:start"
       end
     end
   end


### PR DESCRIPTION
Suggested extra warning. If ts:index isn't run before start, searchd will fail to start, but the log file will be completely empty.
