### PR TITLE
Start in foreground

### DIFF
--- a/lib/thinking_sphinx/tasks.rb
+++ b/lib/thinking_sphinx/tasks.rb
@@ -110,7 +110,7 @@ namespace :thinking_sphinx do
   desc "Run Sphinx in foreground"
   task :start_foreground => :app_env do
     config = ThinkingSphinx::Configuration.instance
-    exec "#{ts.bin_path}#{ts.searchd_binary_name} --pidfile --config #{ts.config_file} --nodetach"
+    exec "#{config.bin_path}#{config.searchd_binary_name} --pidfile --config #{config.config_file} --nodetach"
   end
 end
 
@@ -136,6 +136,8 @@ namespace :ts do
   task :config  => "thinking_sphinx:configure"
   desc "Stop Sphinx (if it's running), rebuild the indexes, and start Sphinx"
   task :rebuild => "thinking_sphinx:rebuild"
+  desc "Run Sphinx in foreground"
+  task :start_foreground => "thinking_sphinx:start_foreground"
 end
 
 def sphinx_pid


### PR DESCRIPTION
I added another rake task to start sphinx with --nodetach option. This is useful for when you're starting Sphinx with something like [Foreman](https://github.com/ddollar/foreman)

When stopping Foreman it pushes a SIGTERM to processes which will end Sphinx safely (not killing active search queries).

Also helpful if you just want to see Sphinx running.
