### PR TITLE
Allow an arbitrary number of named delta indices

### DIFF
--- a/lib/thinking_sphinx/active_record.rb
+++ b/lib/thinking_sphinx/active_record.rb
@@ -238,7 +238,7 @@ module ThinkingSphinx
 
       def delta_index_names
         define_indexes
-        sphinx_indexes.select(&:delta?).collect(&:delta_name)
+        sphinx_indexes.select(&:delta?).collect(&:delta_names).flatten
       end
 
       def to_riddle

--- a/lib/thinking_sphinx/active_record/attribute_updates.rb
+++ b/lib/thinking_sphinx/active_record/attribute_updates.rb
@@ -22,7 +22,9 @@ module ThinkingSphinx
 
           update_index index.core_name, attribute_names, attribute_values
           next unless index.delta?
-          update_index index.delta_name, attribute_names, attribute_values
+          index.enumerate_delta_names do |delta_name|
+            update_index delta_name, attribute_names, attribute_values
+          end
         end
 
         true

--- a/lib/thinking_sphinx/deltas/default_delta.rb
+++ b/lib/thinking_sphinx/deltas/default_delta.rb
@@ -2,10 +2,12 @@ module ThinkingSphinx
   module Deltas
     class DefaultDelta
       attr_accessor :column
+      attr_accessor :stages
       
       def initialize(index, options)
         @index  = index
         @column = options.delete(:delta_column) || :delta
+        @stages = options.delete(:delta_stages) || ['a']
       end
       
       def index(model, instance = nil)

--- a/lib/thinking_sphinx/source.rb
+++ b/lib/thinking_sphinx/source.rb
@@ -53,9 +53,9 @@ module ThinkingSphinx
       source
     end
     
-    def to_riddle_for_delta(offset, position)
+    def to_riddle_for_delta(offset, position, stage)
       source = Riddle::Configuration::SQLSource.new(
-        "#{index.delta_name}_#{position}", adapter.sphinx_identifier
+        "#{index.delta_name(stage)}_#{position}", adapter.sphinx_identifier
       )
       source.parent = "#{index.core_name}_#{position}"
       


### PR DESCRIPTION
- DefaultDelta now takes :delta_stages => ['day','hour'] option
- changed delta_name to delta_name( stage_name )
- added delta_names() and enumerate_delta_names{|n| …}

I'm using this because sphinx merge is horribly slow. It usually takes 2-3 minutes. My approach now is to re-index the image_delta_realtime index whenever data changes. I then regularly merge image_delta_realtime into image_delta_day. That's fast, because image_delta_day will only contain the data from throughout the day. At night, i run a full reindex which will then empty image_delta_realtime and image_delta_day.

Btw, thanks for the gem. I've been using it for quite a while now :)

Cheers, Hajo
