### PR TITLE
Resolve invalid SQL Generated for some indexes on Postgres

### DIFF
--- a/lib/thinking_sphinx/adapters/postgresql_adapter.rb
+++ b/lib/thinking_sphinx/adapters/postgresql_adapter.rb
@@ -14,7 +14,7 @@ module ThinkingSphinx
         clause.split('), ').join(") || '#{separator}' || ")
       else
         clause.split(', ').collect { |field|
-          "CAST(COALESCE(#{field}, '') as varchar)"
+          "CAST(COALESCE(#{field}::character, '') as varchar)"
         }.join(" || '#{separator}' || ")
       end
     end


### PR DESCRIPTION
We've discovered that in some circumstances thinking-sphinx is generating SQL that PostgreSQL rejects for some indexes.

Specifically we have an index

```
define_index do
    indexes locatable.tags(:id), :as => :tag_id, :type => :integer
end
```

Which causes the following error to appear when rake ts:index is run against a postgres database

ERROR: index 'giving_location_core': sql_range_query: ERROR:  invalid input syntax for integer: ""
LINE 1: ...ing(array_agg(COALESCE(CAST(COALESCE("tags"."id", '') as var...

(with a caret pointing at the empty quotes in the second argument to COALESCE)

This commit resolves the issue by always casting the column to a character type prior to passing it in.
