### PR TITLE
Support new option 'use_socket' in sphinx.yml

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -196,8 +196,9 @@ module ThinkingSphinx
 
     def use_socket=(use_socket)
       if use_socket
-        @configuration.searchd.listen  = "#{app_root}/tmp/sockets/searchd.sock"
-        self.address = "#{app_root}/tmp/sockets/searchd.sock"
+        socket = "#{app_root}/tmp/sockets/searchd.#{self.environment}.sock"
+        @configuration.searchd.listen = socket
+        self.address = socket
       end
     end
 


### PR DESCRIPTION
The option 'use_socket' can be used as a shortcut to enable unix
sockets instead of TCP connections. This is helpfull when running
more than one instance on a shared host as you don't need to set
specific port numbers.

It uses a socket file named 'tmp/sockets/searchd.ENV.sock' relative
to the application root.

I haven't been able to come up with proper tests in due time, sorry. Thought you would be much faster in implementing them:-)
