### PR TITLE
Added support for MySQL SSL connections

### DIFF
--- a/lib/thinking_sphinx/source.rb
+++ b/lib/thinking_sphinx/source.rb
@@ -97,6 +97,11 @@ module ThinkingSphinx
       source.sql_db   = config[:database]
       source.sql_port = config[:port]
       source.sql_sock = config[:socket]
+
+      # MySQL SSL support
+      source.mysql_ssl_ca   = config[:sslca]   if config[:sslca]
+      source.mysql_ssl_cert = config[:sslcert] if config[:sslcert]
+      source.mysql_ssl_key  = config[:sslkey]  if config[:sslkey]
     end
 
     def set_source_fields(source)

--- a/spec/sphinx_helper.rb
+++ b/spec/sphinx_helper.rb
@@ -18,6 +18,9 @@ class SphinxHelper
       @username = config['username']
       @password = config['password']
       @socket   = config['socket']
+      @sslca    = config['sslca']
+      @sslcert  = config['sslcert']
+      @sslkey   = config['sslkey']
     end
 
     @path = File.expand_path(File.dirname(__FILE__))
@@ -30,7 +33,10 @@ class SphinxHelper
       :username => @username,
       :password => @password,
       :host     => @host,
-      :socket   => @socket
+      :socket   => @socket,
+      :sslca    => @sslca,
+      :sslcert  => @sslcert,
+      :sslkey   => @sslkey
     )
     ActiveRecord::Base.logger = Logger.new(File.open('tmp/activerecord.log', 'a'))
 

--- a/spec/thinking_sphinx/source_spec.rb
+++ b/spec/thinking_sphinx/source_spec.rb
@@ -85,6 +85,10 @@ describe ThinkingSphinx::Source do
       @riddle.sql_host.should == config[:host]
       @riddle.sql_port.should == config[:port]
       @riddle.sql_sock.should == config[:socket]
+
+      @riddle.mysql_ssl_ca.should   == config[:sslca]
+      @riddle.mysql_ssl_cert.should == config[:sslcert]
+      @riddle.mysql_ssl_key.should  == config[:sslkey]
     end
 
     it "should use a environment user if nothing else is provided" do


### PR DESCRIPTION
Passes MySQL SSL configuration details from database.yml (sslca, sslcert and sslkey) to riddle to allow thinking sphinx to connect to a MySQL database that requires (or uses) SSL connections.
