### PR TITLE
Support the RGeo "postgis" adapter

### DIFF
--- a/lib/thinking_sphinx/adapters/abstract_adapter.rb
+++ b/lib/thinking_sphinx/adapters/abstract_adapter.rb
@@ -16,6 +16,8 @@ module ThinkingSphinx
         ThinkingSphinx::MysqlAdapter.new model
       when :postgresql
         ThinkingSphinx::PostgreSQLAdapter.new model
+      when :postgis
+        ThinkingSphinx::PostgreSQLAdapter.new model
       when Class
         adapter.new model
       else
@@ -44,6 +46,8 @@ module ThinkingSphinx
            "ActiveRecord::ConnectionAdapters::NullDBAdapter"
         :mysql
       when "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter"
+        :postgresql
+      when "ActiveRecord::ConnectionAdapters::PostGISAdapter::MainAdapter"
         :postgresql
       when "ActiveRecord::ConnectionAdapters::JdbcAdapter"
         case model.connection.config[:adapter]

--- a/spec/thinking_sphinx/adapters/abstract_adapter_spec.rb
+++ b/spec/thinking_sphinx/adapters/abstract_adapter_spec.rb
@@ -22,6 +22,13 @@ describe ThinkingSphinx::AbstractAdapter do
       adapter.should be_a(ThinkingSphinx::PostgreSQLAdapter)
     end
 
+    it "returns a PostgreSQLAdapter object for :postgis" do
+      ThinkingSphinx::AbstractAdapter.stub(:adapter_for_model => :postgis)
+
+      adapter = ThinkingSphinx::AbstractAdapter.detect(model)
+      adapter.should be_a(ThinkingSphinx::PostgreSQLAdapter)
+    end
+
     it "instantiates the provided class if one is provided" do
       ThinkingSphinx::AbstractAdapter.stub(:adapter_for_model => CustomAdapter)
       CustomAdapter.should_receive(:new).and_return(stub('adapter'))
@@ -106,6 +113,13 @@ describe ThinkingSphinx::AbstractAdapter do
 
     it "translates a normal PostgreSQL adapter" do
       klass.stub(:name => 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter')
+
+      ThinkingSphinx::AbstractAdapter.standard_adapter_for_model(model).
+        should == :postgresql
+    end
+
+    it "translates the RGeo PostGIS adapter" do
+      klass.stub(:name => 'ActiveRecord::ConnectionAdapters::PostGISAdapter::MainAdapter')
 
       ThinkingSphinx::AbstractAdapter.standard_adapter_for_model(model).
         should == :postgresql


### PR DESCRIPTION
The postgis adapter produced by the RGeo project is essentially a copy of the standard postgresql adapter with support for spatial data types.  As such, thinking-sphinx needs only to interpret that adapter as the :postgresql type.  This pull request contains the changes needed to perform the translation.

See https://github.com/dazuma/activerecord-postgis-adapter or "gem install activerecord-postgis-adapter"
