### PR TITLE
Can explicitly specify available types for STI tables

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,4 +1,5 @@
 Edge:
+* Can explicitly specify available types for STI tables instead of automatically discovering them with "SELECT DISTINCT type FROM <table>" (Cedric Maion).
 * Can indicate whether Sphinx should use a socket for connections instead of TCP (Simon Hürlimann).
 * Can have just attribute values returned as search results using `:attributes_only => true` in a search call (Andrew Hunter).
 * Can specify additional local indices for the generated distributed index (usually one per model) (Andrew Hunter).

--- a/lib/thinking_sphinx/active_record.rb
+++ b/lib/thinking_sphinx/active_record.rb
@@ -24,7 +24,7 @@ module ThinkingSphinx
         extend ThinkingSphinx::ActiveRecord::ClassMethods
 
         class << self
-          attr_accessor :sphinx_index_blocks
+          attr_accessor :sphinx_index_blocks, :sphinx_types
 
           def set_sphinx_primary_key(attribute)
             @sphinx_primary_key_attribute = attribute
@@ -54,6 +54,10 @@ module ThinkingSphinx
 
           def sphinx_index_options
             sphinx_indexes.last.options
+          end
+
+          def set_sphinx_types(types)
+            @sphinx_types = types
           end
 
           # Generate a unique CRC value for the model's name, to use to

--- a/lib/thinking_sphinx/source/sql.rb
+++ b/lib/thinking_sphinx/source/sql.rb
@@ -6,9 +6,9 @@ module ThinkingSphinx
       # the version filtered for delta values, send through :delta => true in
       # the options. Won't do much though if the index isn't set up to support a
       # delta sibling.
-      # 
+      #
       # Examples:
-      # 
+      #
       #   source.to_sql
       #   source.to_sql(:delta => true)
       #
@@ -32,10 +32,10 @@ module ThinkingSphinx
       # Simple helper method for the query range SQL - which is a statement that
       # returns minimum and maximum id values. These can be filtered by delta -
       # so pass in :delta => true to get the delta version of the SQL.
-      # 
+      #
       def to_sql_query_range(options={})
         return nil if @index.options[:disable_range]
-        
+
         min_statement = adapter.convert_nulls(
           "MIN(#{quote_column(@model.primary_key_for_sphinx)})", 1
         )
@@ -54,7 +54,7 @@ module ThinkingSphinx
 
       # Simple helper method for the query info SQL - which is a statement that
       # returns the single row for a corresponding id.
-      # 
+      #
       def to_sql_query_info(offset)
         "SELECT * FROM #{@model.quoted_table_name} WHERE " +
         "#{quote_column(@model.primary_key_for_sphinx)} = (($id - #{offset}) / #{ThinkingSphinx.context.indexed_models.size})"
@@ -64,7 +64,7 @@ module ThinkingSphinx
         unique_id_expr = ThinkingSphinx.unique_id_expression(adapter, offset)
 
         (
-          ["#{@model.quoted_table_name}.#{quote_column(@model.primary_key_for_sphinx)} #{unique_id_expr} AS #{quote_column(@model.primary_key_for_sphinx)} "] + 
+          ["#{@model.quoted_table_name}.#{quote_column(@model.primary_key_for_sphinx)} #{unique_id_expr} AS #{quote_column(@model.primary_key_for_sphinx)} "] +
           @fields.collect     { |field|     field.to_select_sql     } +
           @attributes.collect { |attribute| attribute.to_select_sql }
         ).compact.join(", ")
@@ -92,7 +92,7 @@ module ThinkingSphinx
         end
 
         (
-          ["#{@model.quoted_table_name}.#{quote_column(@model.primary_key_for_sphinx)}"] + 
+          ["#{@model.quoted_table_name}.#{quote_column(@model.primary_key_for_sphinx)}"] +
           @fields.collect     { |field|     field.to_group_sql     }.compact +
           @attributes.collect { |attribute| attribute.to_group_sql }.compact +
           @groupings + internal_groupings
@@ -118,10 +118,10 @@ module ThinkingSphinx
       def crc_column
         if @model.table_exists? &&
           @model.column_names.include?(@model.inheritance_column)
-          
+
           types = types_to_crcs
           return @model.to_crc32.to_s if types.empty?
-          
+
           adapter.case(adapter.convert_nulls(
             adapter.quote_with_table(@model.inheritance_column)),
             types, @model.to_crc32)
@@ -129,7 +129,7 @@ module ThinkingSphinx
           @model.to_crc32.to_s
         end
       end
-      
+
       def internal_class_column
         if @model.table_exists? &&
           @model.column_names.include?(@model.inheritance_column)
@@ -138,14 +138,14 @@ module ThinkingSphinx
           "'#{@model.name}'"
         end
       end
-      
+
       def type_values
-        @model.connection.select_values <<-SQL
+        @model.sphinx_types.presence or @model.connection.select_values <<-SQL
 SELECT DISTINCT #{@model.inheritance_column}
 FROM #{@model.table_name}
         SQL
       end
-      
+
       def types_to_crcs
         type_values.compact.inject({}) { |hash, type|
           hash[type] = type.to_crc32

--- a/spec/thinking_sphinx/active_record_spec.rb
+++ b/spec/thinking_sphinx/active_record_spec.rb
@@ -419,6 +419,25 @@ describe ThinkingSphinx::ActiveRecord do
     end
   end
 
+  describe '#types_for_sphinx' do
+    before :each do
+      @person = Person.find(:first)
+    end
+
+    after :each do
+      Person.set_sphinx_types nil
+    end
+
+    it "should return nil by default" do
+      @person.sphinx_types.should == nil
+    end
+
+    it "should return the specified value" do
+      Person.set_sphinx_types %w(Person Parent)
+      @person.sphinx_types.should == %w(Person Parent)
+    end
+  end
+
   describe '.sphinx_index_names' do
     it "should return the core index" do
       Alpha.define_index { indexes :name }


### PR DESCRIPTION
Patch for issue 311 (https://github.com/freelancing-god/thinking-sphinx/issues/311).
This introduces a set_sphinx_types method to explicitly define subclasses for Sphinx, and thus avoids having to run "SELECT DISTINCT type FROM table" (which is slow on huge tables when the type columns is not indexed).

class Product < ActiveRecord::Base
  set_sphinx_types %w(ProductTypeA ProductTypeB)
  define_index do
    [...]
  end
end
