### PR TITLE
hard_retry_count feature

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -60,7 +60,7 @@ module ThinkingSphinx
     IndexOptions  = Riddle::Configuration::Index.settings.map     { |setting|
       setting.to_s
     } - %w( source prefix_fields infix_fields )
-    CustomOptions = %w( disable_range use_64_bit )
+    CustomOptions = %w( disable_range use_64_bit hard_retry_count )
 
     attr_accessor :searchd_file_path, :allow_star, :app_root,
       :model_directories, :delayed_job_priority, :indexed_models, :use_64_bit,

--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -420,27 +420,40 @@ module ThinkingSphinx
     def populate
       return if @populated
       @populated = true
+      retries   = hard_retries
 
-      retry_on_stale_index do
-        begin
-          log query do
-            @results = client.query query, indexes, comment
+      begin
+        retry_on_stale_index do
+          begin
+            log query do
+              @results = client.query query, indexes, comment
+            end
+            total = @results[:total_found].to_i
+            log "Found #{total} result#{'s' unless total == 1}"
+
+            log "Sphinx Daemon returned warning: #{warning}" if warning?
+
+            if error?
+              log "Sphinx Daemon returned error: #{error}"
+              raise SphinxError.new(error, @results) unless options[:ignore_errors]
+            end
+          rescue Errno::ECONNREFUSED => err
+            raise ThinkingSphinx::ConnectionError,
+              'Connection to Sphinx Daemon (searchd) failed.'
           end
-          total = @results[:total_found].to_i
-          log "Found #{total} result#{'s' unless total == 1}"
 
-          log "Sphinx Daemon returned warning: #{warning}" if warning?
-
-          if error?
-            log "Sphinx Daemon returned error: #{error}"
-            raise SphinxError.new(error, @results) unless options[:ignore_errors]
-          end
-        rescue Errno::ECONNREFUSED => err
-          raise ThinkingSphinx::ConnectionError,
-            'Connection to Sphinx Daemon (searchd) failed.'
+          compose_results
         end
-
-        compose_results
+      rescue => e
+        log 'Caught Sphinx exception: %s (%s %s left)' % [
+          e.message, retries, (retries == 1 ? 'try' : 'tries')
+        ]
+        retries -= 1
+        if retries >= 0
+          retry
+        else
+          raise e
+        end
       end
     end
 
@@ -859,6 +872,10 @@ module ThinkingSphinx
       else
         options[:retry_stale].to_i
       end
+    end
+
+    def hard_retries
+      options[:hard_retry_count] ? options[:hard_retry_count] : (config.index_options[:hard_retry_count] ? config.index_options[:hard_retry_count] : 0)
     end
 
     def include_for_class(klass)


### PR DESCRIPTION
Added ability to specify :hard_retry_count parameter to searches that tells ruby how many times to retry a sphinx query if it catches any kind of exception:

Model.search :hard_retry_count => 3

The default is 0, but it can be overridden in an initializer method as follows:
ThinkingSphinx::Search::HARD_RETRY_COUNT = 3
