### PR TITLE
hard_retry_count feature

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -28,6 +28,7 @@ module ThinkingSphinx
   # html remove elements::  ''
   # searchd_binary_name::   searchd
   # indexer_binary_name::   indexer
+  # hard_retry_count::      0
   #
   # If you want to change these settings, create a YAML file at
   # config/sphinx.yml with settings for each environment, in a similar
@@ -64,7 +65,7 @@ module ThinkingSphinx
 
     attr_accessor :searchd_file_path, :allow_star, :app_root,
       :model_directories, :delayed_job_priority, :indexed_models, :use_64_bit,
-      :touched_reindex_file, :stop_timeout, :version, :shuffle
+      :touched_reindex_file, :stop_timeout, :version, :shuffle, :hard_retry_count
 
     attr_accessor :source_options, :index_options
 
@@ -111,6 +112,7 @@ module ThinkingSphinx
       self.delayed_job_priority = 0
       self.indexed_models       = []
       self.shuffle              = false
+      self.hard_retry_count     = 0
 
       self.source_options  = {}
       self.index_options   = {

--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -420,27 +420,40 @@ module ThinkingSphinx
     def populate
       return if @populated
       @populated = true
+      retries   = hard_retries
 
-      retry_on_stale_index do
-        begin
-          log query do
-            @results = client.query query, indexes, comment
+      begin
+        retry_on_stale_index do
+          begin
+            log query do
+              @results = client.query query, indexes, comment
+            end
+            total = @results[:total_found].to_i
+            log "Found #{total} result#{'s' unless total == 1}"
+
+            log "Sphinx Daemon returned warning: #{warning}" if warning?
+
+            if error?
+              log "Sphinx Daemon returned error: #{error}"
+              raise SphinxError.new(error, @results) unless options[:ignore_errors]
+            end
+          rescue Errno::ECONNREFUSED => err
+            raise ThinkingSphinx::ConnectionError,
+              'Connection to Sphinx Daemon (searchd) failed.'
           end
-          total = @results[:total_found].to_i
-          log "Found #{total} result#{'s' unless total == 1}"
 
-          log "Sphinx Daemon returned warning: #{warning}" if warning?
-
-          if error?
-            log "Sphinx Daemon returned error: #{error}"
-            raise SphinxError.new(error, @results) unless options[:ignore_errors]
-          end
-        rescue Errno::ECONNREFUSED => err
-          raise ThinkingSphinx::ConnectionError,
-            'Connection to Sphinx Daemon (searchd) failed.'
+          compose_results
         end
-
-        compose_results
+      rescue => e
+        log 'Caught Sphinx exception: %s (%s %s left)' % [
+          e.message, retries, (retries == 1 ? 'try' : 'tries')
+        ]
+        retries -= 1
+        if retries >= 0
+          retry
+        else
+          raise e
+        end
       end
     end
 
@@ -859,6 +872,10 @@ module ThinkingSphinx
       else
         options[:retry_stale].to_i
       end
+    end
+
+    def hard_retries
+      options[:hard_retry_count] ? options[:hard_retry_count] : config.hard_retry_count
     end
 
     def include_for_class(klass)

--- a/spec/thinking_sphinx/search_spec.rb
+++ b/spec/thinking_sphinx/search_spec.rb
@@ -411,6 +411,28 @@ describe ThinkingSphinx::Search do
           'baz @foo bar @(foo,bar) baz', :star => true
         ).first
       end
+
+      it "should try retry query up to the hard_retry_count option times if it catches an exception" do
+        @client.should_receive(:query).exactly(4).and_raise("Test Exception")
+        expect { ThinkingSphinx::Search.new(:hard_retry_count => 3).first }.to raise_error("Test Exception")
+      end
+
+      it "should not retry query if hard_retry_count option is not set" do
+        @client.should_receive(:query).exactly(1).and_raise("Test Exception")
+        expect { ThinkingSphinx::Search.new.first }.to raise_error("Test Exception")
+      end
+
+      it "should allow the hard_retry_count to be globally set as a configuration option" do
+        @config.hard_retry_count = 2
+        @client.should_receive(:query).exactly(3).and_raise("Test Exception")
+        expect { ThinkingSphinx::Search.new.first }.to raise_error("Test Exception")
+      end
+
+      it "should give priority to the hard_retry_count search option over the globally configured option" do
+        @config.hard_retry_count = 4
+        @client.should_receive(:query).exactly(2).and_raise("Test Exception")
+        expect { ThinkingSphinx::Search.new(:hard_retry_count => 1).first }.to raise_error("Test Exception")
+      end
     end
 
     describe 'comment' do


### PR DESCRIPTION
Added new feature which allows searches to retry x number of times. I realize there are already options that may be specified directly to Sphinx, but these were found to be insufficient and we found ourselves still getting sphinx exceptions. This code surrounds the search and a rescue block and will retry the search x number of times.

There are two ways "x" can be defined:

Globally (in sphinx.yml):
production:
  hard_retry_count: 3

Or directly on a specific search:
Model.search(:hard_retry_count => 4)
