### PR TITLE
#excerpts_for should send raw query string to riddle

### DIFF
--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -362,7 +362,7 @@ module ThinkingSphinx
       client.excerpts(
         {
           :docs   => [string.to_s],
-          :words  => results[:words].keys.join(' '),
+          :words  => query,
           :index  => index.split(',').first.strip
         }.merge(options[:excerpt_options] || {})
       ).first

--- a/spec/thinking_sphinx/search_spec.rb
+++ b/spec/thinking_sphinx/search_spec.rb
@@ -1309,7 +1309,7 @@ describe ThinkingSphinx::Search do
         :matches => [],
         :words => {'one' => {}, 'two' => {}}
       })
-      @search = ThinkingSphinx::Search.new(:classes => [Alpha])
+      @search = ThinkingSphinx::Search.new('reading comprehension', :classes => [Alpha])
     end
 
     it "should return the Sphinx excerpt value" do
@@ -1341,9 +1341,9 @@ describe ThinkingSphinx::Search do
       @search.excerpt_for('string', Beta)
     end
 
-    it "should join the words together" do
+    it "should use the query string" do
       @client.should_receive(:excerpts) do |options|
-        options[:words].should == @search.results[:words].keys.join(' ')
+        options[:words].should == 'reading comprehension'
       end
 
       @search.excerpt_for('string', Beta)


### PR DESCRIPTION
Noticed a problem where the search term "reading comprehension" was not highlighting the word "comprehension".  Turns out TS was passing the stemmed word, in this case "comprehens", and GetExcerpts was then re-stemming that to "comprehen" and not finding anything to highlight for that word.

According to the [sphinx docs](http://sphinxsearch.com/docs/current.html#api-func-buildexcerpts) for GetExcerpts:

> $words is a string that contains the keywords to highlight. They will be processed with respect to index settings. For instance, if English stemming is enabled in the index, "shoes" will be highlighted even if keyword is "shoe"

Also, passing the raw query to riddle will allow the use of the `:query_mode` parameter to be used effectively.
