### PR TITLE
Use Ruby 1.9.x's "BasicObject" in place of BlankSlate when available

### DIFF
--- a/lib/thinking_sphinx/index/builder.rb
+++ b/lib/thinking_sphinx/index/builder.rb
@@ -1,4 +1,4 @@
-require 'blankslate'
+require 'blankslate' unless defined?(BasicObject)
 
 module ThinkingSphinx
   class Index
@@ -14,7 +14,7 @@ module ThinkingSphinx
     # set_property allows you to set some settings on a per-index basis. Check
     # out each method's documentation for better ideas of usage.
     #
-    class Builder < BlankSlate
+    class Builder < (defined?(BasicObject) ? BasicObject : BlankSlate)
       def self.generate(model, name = nil, &block)
         index  = ThinkingSphinx::Index.new(model)
         index.name = name unless name.nil?


### PR DESCRIPTION
With the 3.0.2 release of Builder, requiring thinking_sphinx leads to
the following warning message:

  gems/builder-3.0.2/lib/blankslate.rb:51: warning: undefining `object_id' may cause serious problems

Where possible, then, it makes sense to use BasicObject instead to avoid the warning message
getting barfed out every time rake or "rails console" is invoked.
