### PR TITLE
Fix model-centric searching when using skip_sti

### DIFF
--- a/lib/thinking_sphinx/search/merger.rb
+++ b/lib/thinking_sphinx/search/merger.rb
@@ -10,9 +10,10 @@ class ThinkingSphinx::Search::Merger
       when :conditions, :with, :without, :with_all, :without_all
         @search.options[key] ||= {}
         @search.options[key].merge! value
-      when :without_ids
+      when :without_ids, :classes
         @search.options[key] ||= []
         @search.options[key] += value
+        @search.options[key].uniq!
       else
         @search.options[key] = value
       end

--- a/spec/acceptance/searching_with_sti_spec.rb
+++ b/spec/acceptance/searching_with_sti_spec.rb
@@ -43,4 +43,13 @@ describe 'Searching across STI models', :live => true do
 
     Bird.search.to_a.should == [duck]
   end
+
+  it "obeys :classes if supplied" do
+    platypus = Animal.create :name => 'Platypus'
+    duck     = Bird.create :name => 'Duck'
+    emu      = FlightlessBird.create :name => 'Emu'
+    index
+
+    Bird.search(nil, :skip_sti => true, :classes=>[Bird, FlightlessBird]).to_a.should == [duck, emu]
+  end
 end

--- a/spec/thinking_sphinx/active_record/base_spec.rb
+++ b/spec/thinking_sphinx/active_record/base_spec.rb
@@ -8,6 +8,11 @@ describe ThinkingSphinx::ActiveRecord::Base do
       def self.name; 'Model'; end
     end
   }
+  let(:sub_model) {
+    Class.new(model) do
+      def self.name; 'SubModel'; end
+    end
+  }
   let(:search) { double('search', :options => {})}
 
   describe '.search' do
@@ -27,6 +32,12 @@ describe ThinkingSphinx::ActiveRecord::Base do
 
     it "scopes the search to a given model" do
       model.search('pancakes').options[:classes].should == [model]
+    end
+    
+    it "merges the :classes option with the model" do
+      search_options = {:classes=>[sub_model]}
+      search.stub :options => search_options
+      model.search('pancakes', search_options).options[:classes].should == [sub_model, model]
     end
   end
 


### PR DESCRIPTION
BaseClass.search('foo', :skip_sti=>true, :classes=>[SubClass]) would fail due to Merger overwriting the :classes option.

Slightly different approach to the original one I proposed in https://github.com/pat/thinking-sphinx/issues/384, but this seems cleaner.  WDYT?
