### PR TITLE
Allow setting custom sql_query_pre in config

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -53,7 +53,7 @@ module ThinkingSphinx
 
     SourceOptions = Riddle::Configuration::SQLSource.settings.map { |setting|
       setting.to_s
-    } - %w( type sql_query_pre sql_query sql_joined_field sql_file_field
+    } - %w( type sql_query sql_joined_field sql_file_field
       sql_query_range sql_attr_uint sql_attr_bool sql_attr_bigint sql_query_info
       sql_attr_timestamp sql_attr_str2ordinal sql_attr_float sql_attr_multi
       sql_attr_string sql_attr_str2wordcount sql_column_buffers sql_field_string


### PR DESCRIPTION
Hi,

I'd like to set a custom sql_query_pre for Sphinx, but TS seems to blacklist (i.e. ignore) this option. Simply adding it to TS::Configuration::SourceOptions seems to have no ill-effects.

Any objections to adding it?

Thanks!
George
