### PR TITLE
TS::Test should use suppress_delta_output correctly

### DIFF
--- a/lib/thinking_sphinx/test.rb
+++ b/lib/thinking_sphinx/test.rb
@@ -1,7 +1,7 @@
 class ThinkingSphinx::Test
   def self.init(suppress_delta_output = true)
     FileUtils.mkdir_p config.indices_location
-    config.settings['quiet_deltas'] = true
+    config.settings['quiet_deltas'] = suppress_delta_output
   end
 
   def self.start


### PR DESCRIPTION
`suppress_delta_output` is not actually being used for anything, so it's always silencing deltas.

This fixes that.
