### PR TITLE
config.build should be config.render_to_file

### DIFF
--- a/lib/thinking_sphinx/test.rb
+++ b/lib/thinking_sphinx/test.rb
@@ -5,7 +5,7 @@ class ThinkingSphinx::Test
   end
 
   def self.start
-    config.build
+    config.render_to_file
     config.controller.index
     config.controller.start
   end


### PR DESCRIPTION
Another change to ThinkingSphinx::Test to make config.build instead refer to
config.render_to_file which appears to be the correct solution now?
