### PR TITLE
Correctly escape the null in the internal class column

### DIFF
--- a/lib/thinking_sphinx/active_record/sql_source/template.rb
+++ b/lib/thinking_sphinx/active_record/sql_source/template.rb
@@ -30,7 +30,9 @@ class ThinkingSphinx::ActiveRecord::SQLSource::Template
 
   def class_column
     if inheriting?
-      source.adapter.convert_nulls model.inheritance_column, "'#{model.name}'"
+      adapter = source.adapter
+      quoted_column = "#{adapter.quoted_table_name}.#{adapter.quote(model.inheritance_column)}"
+      source.adapter.convert_nulls quoted_column, "'#{model.sti_name}'"
     else
       "'#{model.name}'"
     end


### PR DESCRIPTION
The code that generates the sphinx_internal_class as part of the sphinx SQL has an issue with it specifying an unscoped column where by it if you reference an associated with the type column, it will raise an error.

This fixes it by using the full column specifier. Note: I couldn't get the specs running (going to try more) and wasn't sure the best way to test this in TS code, so if you have suggestions I'd be happy to add tests for it as well.

Thanks!
