### PR TITLE
Warning messages with concerns

### DIFF
--- a/lib/thinking_sphinx/context.rb
+++ b/lib/thinking_sphinx/context.rb
@@ -54,7 +54,7 @@ class ThinkingSphinx::Context
       Dir["#{base}**/*.rb"].each do |file|
         model_name = file.gsub(/^#{base}([\w_\/\\]+)\.rb/, '\1')
 
-        next if model_name.nil?
+        next if model_name.nil? || model_name.match(/^concerns\//)
         camelized_model = model_name.camelize
         next if ::ActiveRecord::Base.descendants.detect { |model|
           model.name == camelized_model


### PR DESCRIPTION
Because concerns will be part of rails 4 and the default directory for models concerns will be app/models/concerns, You need to ignore the entire directory in order to avoid the generated error when constantize the not well formed "Concerns::your_module_name"
