### PR TITLE
Check AR::Base#descendants on model subfolder retries in ThinkingSphinx::Context#load_models

### DIFF
--- a/lib/thinking_sphinx/context.rb
+++ b/lib/thinking_sphinx/context.rb
@@ -56,11 +56,11 @@ class ThinkingSphinx::Context
 
         next if model_name.nil?
         camelized_model = model_name.camelize
-        next if ::ActiveRecord::Base.descendants.detect { |model|
-          model.name == camelized_model
-        }
 
         begin
+          next if ::ActiveRecord::Base.descendants.detect { |model|
+            model.name == camelized_model
+          }
           camelized_model.constantize
         rescue LoadError, NameError
           # Make sure that STI subclasses in subfolders are loaded.


### PR DESCRIPTION
Moving the AR::Base.descendants check into the begin..end block so that it can be a part of the retry logic.
