### PR TITLE
Suppress logging to STDERR when swallowing class load errors

### DIFF
--- a/lib/thinking_sphinx/context.rb
+++ b/lib/thinking_sphinx/context.rb
@@ -64,12 +64,7 @@ class ThinkingSphinx::Context
           camelized_model.constantize
         rescue LoadError, NameError
           # Make sure that STI subclasses in subfolders are loaded.
-          if camelized_model.gsub!(/.+::/, '').nil?
-            STDERR.puts "ThinkingSphinx: error loading #{file}"
-            next
-          else
-            retry
-          end
+          camelized_model.gsub!(/.+::/, '').nil? ?  next : retry
         rescue Exception => err
           STDERR.puts "Warning: Error loading #{file}:"
           STDERR.puts err.message

--- a/spec/thinking_sphinx/context_spec.rb
+++ b/spec/thinking_sphinx/context_spec.rb
@@ -31,20 +31,16 @@ describe ThinkingSphinx::Context do
       }.should_not raise_error
     end
 
-    it "should report name errors but not raise them" do
+    it "should not raise name errors" do
       class_name.stub(:constantize).and_raise(NameError)
-      STDERR.stub!(:puts => '')
-      STDERR.should_receive(:puts).with('ThinkingSphinx: error loading a.rb')
 
       lambda {
         ts_context.prepare
       }.should_not raise_error
     end
 
-    it "should report load errors but not raise them" do
+    it "should not raise load errors" do
       class_name.stub(:constantize).and_raise(LoadError)
-      STDERR.stub!(:puts => '')
-      STDERR.should_receive(:puts).with('ThinkingSphinx: error loading a.rb')
 
       lambda {
         ts_context.prepare


### PR DESCRIPTION
This removes a log message that was added about a month ago.  

One of our applications makes some heavy use of STI and we were seeing a few error messages being written to STDERR by ThinkingSphinx::Context#load_models even though the indices were being generated correctly.  I believe the problem stems from trying to force loading models while the application is currently in the middle of loading.

For instance, we have something roughly similar to:

``` ruby
class A < ActiveRecord::Base
  define_index do
  ....
  end
end

define B < A
end

define C < B
end

define SomeObserver < ActiveRecord::Observer
  observes :b, :c
end
```

What I see is that first, SomeObserver is loaded by rails, which in turn tries to constantize 'B', which triggers loading of class A and the definition of A's index.  Defining the index triggers a call to #load_models which will eventually try to constantize 'C', which will error out with a NameError on 'B'.  My hypothesis is that this a cycle prevention mechanism in the class loader to avoid infinite loops.

Since these errors are otherwise being ignored, this just skips the logging.
