### PR TITLE
Support new JDBC configuration style.

### DIFF
--- a/lib/thinking_sphinx/adapters/abstract_adapter.rb
+++ b/lib/thinking_sphinx/adapters/abstract_adapter.rb
@@ -51,6 +51,13 @@ module ThinkingSphinx
           :mysql
         when "jdbcpostgresql"
           :postgresql
+        when "jdbc"
+          match = /^jdbc:(?<adapter>mysql|postgresql):\/\//.match(model.connection.config[:url])
+          if match
+            match[:adapter].to_sym
+          else
+            model.connection.config[:adapter]
+          end
         else
           model.connection.config[:adapter].to_sym
         end

--- a/spec/thinking_sphinx/adapters/abstract_adapter_spec.rb
+++ b/spec/thinking_sphinx/adapters/abstract_adapter_spec.rb
@@ -127,6 +127,24 @@ describe ThinkingSphinx::AbstractAdapter do
         should == :postgresql
     end
 
+   it "translates a JDBC adapter with MySQL connection string to MySQL" do
+      klass.stub(:name => 'ActiveRecord::ConnectionAdapters::JdbcAdapter')
+      connection.stub(:config => {:adapter => 'jdbc',
+                                  :url => 'jdbc:mysql://127.0.0.1:3306/sphinx'})
+
+      ThinkingSphinx::AbstractAdapter.standard_adapter_for_model(model).
+        should == :mysql
+    end
+
+    it "translates a JDBC adapter with PostgresSQL connection string to PostgresSQL" do
+      klass.stub(:name => 'ActiveRecord::ConnectionAdapters::JdbcAdapter')
+      connection.stub(:config => {:adapter => 'jdbc',
+                                  :url => 'jdbc:postgresql://127.0.0.1:3306/sphinx'})
+
+      ThinkingSphinx::AbstractAdapter.standard_adapter_for_model(model).
+        should == :postgresql
+    end
+
     it "returns other JDBC adapters without translation" do
       klass.stub(:name => 'ActiveRecord::ConnectionAdapters::JdbcAdapter')
       connection.stub(:config => {:adapter => 'jdbcmssql'})


### PR DESCRIPTION
Please see: https://github.com/jruby/activerecord-jdbc-adapter

activerecord-jdbc-adapter supports a newer style database.yml configuration that accepts just, "jdbc" as the adapter type rather than "jdbcmysql". It then requires a database-specific jdbc connection string. There are certain cases where one must use this new syntax. See below for an example of the database.yml syntax.

This pull request adds support for this new style jdbc config, and includes passing specs. Thank you!

``` ruby
development:
  adapter: jdbc
  username: blog
  password:
  driver: com.mysql.jdbc.Driver
  url: jdbc:mysql://localhost:3306/weblog_development
```
