### PR TITLE
Add disable_range? option to index created

### DIFF
--- a/lib/thinking_sphinx/active_record/index.rb
+++ b/lib/thinking_sphinx/active_record/index.rb
@@ -62,7 +62,7 @@ class ThinkingSphinx::ActiveRecord::Index < Riddle::Configuration::Index
       :offset          => offset,
       :delta?          => @options[:delta?],
       :delta_processor => @options[:delta_processor],
-      :disable_range?  => @options[:disable_range?]
+      :disable_range?  => @options[:disable_range?],
       :primary_key     => @options[:primary_key] || model.primary_key || :id
     }
   end


### PR DESCRIPTION
In some (relatively obscure) cases, ranged sql won't work properly.  Minor change would allow you to pass disable_ranged? => true to Index.define to disable ranged sql.
