### PR TITLE
Add deployment tasks for use with Capistrano

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -12,6 +12,7 @@ Edge:
 * [FIX] Thinking Sphinx can be loaded via thinking/sphinx, to satisfy Bundler.
 * [FEATURE] indexer and searchd settings are added to the appropriate objects from config/thinking_sphinx.yml (@ygelfand).
 * [FIX] New lines are maintained and escaped in sql_query values.
+* [FEATURE] Provide Capistrano deployment tasks (@davidcelis).
 
 2013-01-02: 3.0.0
 * [CHANGE] Updating Riddle dependency to 1.5.4.

--- a/README.textile
+++ b/README.textile
@@ -189,6 +189,17 @@ All panes namespaced to @ThinkingSphinx::Panes@, and the @DistancePane@ is autom
 
 If you wish to add your own panes, go ahead. The only requirement is that the initializer must accept three arguments: the search context, the underlying search result object, and a hash of the raw values from Sphinx.
 
+h2. Deployment with Capistrano
+
+Thinking Sphinx comes with several Capistrano tasks to help ease deployment of your applications. Just require the recipes:
+
+```ruby
+# config/deploy.rb
+require 'thinking_sphinx/capistrano'
+```
+
+When running `cap deploy:setup` to get your server ready for deployments, Thinking Sphinx will also set up a shared folder for your indexes. Before finalizing a deployment, these indexes will be symlinked into the release path for use. When you deploy your application for the first time using `cap deploy:cold`, your indexes will be built for you and the search daemon will be started. Run `cap -T` to see all of the deployment tasks.
+
 h2. Limitations
 
 Almost all functionality from v2 releases are implemented, though it's worth noting that some settings haven't yet been brought across, and a handful of the smaller features don't yet exist either. Some may actually not return... we'll see.
@@ -199,7 +210,6 @@ May or may not be added:
 * Bitmask weighting helper
 * Timezone support (for databases not using UTC)
 * Abstract Inheritance support (maybe - not sure this is something many of people want).
-* Capistrano Tasks
 * Facet support for arrays of strings.
 
 h3. Sphinx Versions

--- a/lib/thinking_sphinx/capistrano.rb
+++ b/lib/thinking_sphinx/capistrano.rb
@@ -1,0 +1,64 @@
+Capistrano::Configuration.instance(:must_exist).load do
+  namespace :thinking_sphinx do
+    desc 'Generate the Sphinx configuration file.'
+    task :configure do
+      rake 'thinking_sphinx:configure'
+    end
+
+    desc 'Build Sphinx indexes into the shared path and symlink them into your release.'
+    task :index do
+      rake 'thinking_sphinx:index'
+    end
+    after 'thinking_sphinx:index', 'thinking_sphinx:symlink_indexes'
+
+    desc 'Start the Sphinx search daemon.'
+    task :start do
+      rake 'thinking_sphinx:start'
+    end
+    before 'thinking_sphinx:start', 'thinking_sphinx:configure'
+
+    desc 'Stop the Sphinx search daemon.'
+    task :stop do
+      rake 'thinking_sphinx:stop'
+    end
+
+    desc 'Restart the Sphinx search daemon.'
+    task :restart do
+      rake 'thinking_sphinx:stop thinking_sphinx:configure thinking_sphinx:start'
+    end
+
+    desc <<-DESC
+Stop, reindex, and then start the Sphinx search daemon. This task must be executed \
+if you alter the structure of your indexes.
+    DESC
+    task :rebuild do
+      rake 'thinking_sphinx:stop thinking_sphinx:reindex'
+    end
+    after 'thinking_sphinx:rebuild', 'thinking_sphinx:symlink_indexes'
+    after 'thinking_sphinx:rebuild', 'thinking_sphinx:start'
+
+    desc 'Create the shared folder for sphinx indexes.'
+    task :shared_sphinx_folder do
+      rails_env = fetch(:rails_env, 'production')
+      run "mkdir -p #{shared_path}/db/sphinx/#{rails_env}"
+    end
+
+    desc 'Symlink Sphinx indexes from the shared folder to the latest release.'
+    task :symlink_indexes do
+      run "if [ -d #{release_path} ]; then ln -nfs #{shared_path}/db/sphinx #{release_path}/db/sphinx; else ln -nfs #{shared_path}/db/sphinx #{current_path}/db/sphinx; fi;"
+    end
+
+    # Logical flow for deploying an app
+    after  'deploy:cold',            'thinking_sphinx:index'
+    after  'deploy:cold',            'thinking_sphinx:start'
+    after  'deploy:setup',           'thinking_sphinx:shared_sphinx_folder'
+    after  'deploy:finalize_update', 'thinking_sphinx:symlink_indexes'
+
+    def rake(tasks)
+      rails_env = fetch(:rails_env, 'production')
+      rake = fetch(:rake, 'rake')
+
+      run "if [ -d #{release_path} ]; then cd #{release_path}; else cd #{current_path}; fi; if [ -f Rakefile ]; then #{rake} RAILS_ENV=#{rails_env} #{tasks}; fi;"
+    end
+  end
+end


### PR DESCRIPTION
This script, when required into a user's deployment script, provides
several useful tasks for deploying an application with Thinking Sphinx.
These tasks are:
- `cap thinking_sphinx:configure`: Generate the .conf file
- `cap thinking_sphinx:index`: Build Sphinx indexes
- `...:rebuild`: Stop, rebuild indexes, and start the search daemon
- `...:stop`: Stop the search daemon
- `...:start`: Start the search daemon
- `...:restart`: Restart the search daemon
- `...:shared_sphinx_folder`: Create a shared folder for indexes
- `...:symlink_indexes`: Symlink indexes into the latest release

Additionally, the `thinking_sphinx/capistrano` script will setup some
logical flow for deployments. After a cold deploy, indexes will be built
for the user and the search daemon will start up. During a
`cap deploy:setup`, a shared folder will be created to store Sphinx
indexes. Finally, after each release is finalized, symlinks to the
shared indexes will be created.

This commit closes #447.

Signed-off-by: David Celis me@davidcel.is
