### PR TITLE
removed named capture to be compatible with Ruby 1.8

### DIFF
--- a/lib/thinking_sphinx/adapters/abstract_adapter.rb
+++ b/lib/thinking_sphinx/adapters/abstract_adapter.rb
@@ -52,9 +52,9 @@ module ThinkingSphinx
         when "jdbcpostgresql"
           :postgresql
         when "jdbc"
-          match = /^jdbc:(?<adapter>mysql|postgresql):\/\//.match(model.connection.config[:url])
+          match = /^jdbc:(mysql|postgresql):\/\//.match(model.connection.config[:url])
           if match
-            match[:adapter].to_sym
+            match[1].to_sym
           else
             model.connection.config[:adapter]
           end


### PR DESCRIPTION
The original code generates and exception on Ruby 1.8:
`undefined (?...) sequence: /^jdbc:(?<adapter>mysql|postgresql):\/\// (SyntaxError)`
