### PR TITLE
Modified ThinkingSphinx::Search::Query.to_s to handle null conditions and empty conditions

### DIFF
--- a/lib/thinking_sphinx/search/query.rb
+++ b/lib/thinking_sphinx/search/query.rb
@@ -13,7 +13,7 @@ class ThinkingSphinx::Search::Query
 
   def to_s
     (star_keyword(keywords) + ' ' + conditions.keys.collect { |key|
-      "@#{key} #{star_keyword conditions[key], key}"
+      "@#{key} #{star_keyword conditions[key], key}" unless ( conditions[key].nil? || conditions[key].empty? )
     }.join(' ')).strip
   end
 

--- a/spec/thinking_sphinx/search/query_spec.rb
+++ b/spec/thinking_sphinx/search/query_spec.rb
@@ -42,5 +42,18 @@ describe ThinkingSphinx::Search::Query do
 
       query.to_s.should == '@sphinx_internal_class article'
     end
+
+    it "handles null values by removing them from the conditions hash" do
+      query = ThinkingSphinx::Search::Query.new '', :title => nil
+
+      query.to_s.should == ''
+    end
+
+    it "handles empty string values by removing them from the conditions hash" do
+      query = ThinkingSphinx::Search::Query.new '', :title => ''
+
+      query.to_s.should == ''
+    end
+
   end
 end


### PR DESCRIPTION
What are your thoughts on this? 

I modified to_s to ignore conditions that are either nil or empty. 

def to_s
    (star_keyword(keywords) + ' ' + conditions.keys.collect { |key|
      "@#{key} #{star_keyword conditions[key], key}" unless ( conditions[key].nil? || conditions[key].empty? )
    }.join(' ')).strip
  end

What is returned in both these cases is similar to a query such as Model.search String.new or Model.search nil.

Thoughts?
