### PR TITLE
Make it possible to use multiple-field search operator

### DIFF
--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -629,7 +629,8 @@ module ThinkingSphinx
       return '' if @options[:conditions].blank?
 
       ' ' + @options[:conditions].keys.collect { |key|
-        "@#{key} #{options[:conditions][key]}"
+        search_key = key.is_a?(::Array) ? "(#{key.join(',')})" : key
+        "@#{search_key} #{options[:conditions][key]}"
       }.join(' ')
     end
 


### PR DESCRIPTION
Hi! I'm working on an old Rails 2 app which uses Thinking Sphinx 1, and I needed to do a search on either of 2 fields. In other words, I want to find documents which contain a search term in _either_ this field _or_ that field.

In the Sphinx docs, I found the following:

```
multiple-field search operator:
@(title,body) hello world
```

This can be accessed in Thinking Sphinx as:

```
Model.search :conditions => {'(field1,field2)' => 'value'}
```

To make this slightly more intuitive, I patched TS so it can also accept:

```
Model.search :conditions => {[:field1,:field2] => 'value'}
```

I don't know if you would like the TS gem to include this functionality. If so, this (small) patch does the trick.
