### PR TITLE
Error in postgresql_adapter.rb (integer out of range - use_64_bit)

### DIFF
--- a/lib/thinking_sphinx/active_record/database_adapters/postgresql_adapter.rb
+++ b/lib/thinking_sphinx/active_record/database_adapters/postgresql_adapter.rb
@@ -10,7 +10,7 @@ class ThinkingSphinx::ActiveRecord::DatabaseAdapters::PostgreSQLAdapter <
   end
 
   def cast_to_timestamp(clause)
-    if ThinkingSphinx::Configuration.instance.settings['use_64_bit']
+    if ThinkingSphinx::Configuration.instance.settings['64bit_timestamps']
       "extract(epoch from #{clause})::bigint"
     else
       "extract(epoch from #{clause})::int"

--- a/spec/thinking_sphinx/active_record/database_adapters/postgresql_adapter_spec.rb
+++ b/spec/thinking_sphinx/active_record/database_adapters/postgresql_adapter_spec.rb
@@ -23,9 +23,16 @@ describe ThinkingSphinx::ActiveRecord::DatabaseAdapters::PostgreSQLAdapter do
   end
 
   describe '#cast_to_timestamp' do
-    it "converts to unix timestamps" do
+    it "converts to int unix timestamps" do
       adapter.cast_to_timestamp('created_at').
         should == 'extract(epoch from created_at)::int'
+    end
+
+    it "converts to bigint unix timestamps" do
+      ThinkingSphinx::Configuration.instance.settings['64bit_timestamps'] = true
+      
+      adapter.cast_to_timestamp('created_at').
+        should == 'extract(epoch from created_at)::bigint'
     end
   end
 


### PR DESCRIPTION
New ThinkingSphinx version 3.0> ignore option use_64_bit in thinking-sphinx.yml for PostgreSQL. sql_range_query: ERROR:  integer out of range (use_64_bit)
