### PR TITLE
Allow INDEX_ONLY=true on Capistrano tasks

### DIFF
--- a/lib/thinking_sphinx/capistrano.rb
+++ b/lib/thinking_sphinx/capistrano.rb
@@ -56,6 +56,7 @@ if you alter the structure of your indexes.
     def rake(tasks)
       rails_env = fetch(:rails_env, 'production')
       rake = fetch(:rake, 'rake')
+      tasks += ' INDEX_ONLY=true' if ENV['INDEX_ONLY'] == 'true'
 
       run "if [ -d #{release_path} ]; then cd #{release_path}; else cd #{current_path}; fi; if [ -f Rakefile ]; then #{rake} RAILS_ENV=#{rails_env} #{tasks}; fi;"
     end


### PR DESCRIPTION
A quick and dirty way to forward the INDEX_ONLY=true env option from Capistrano tasks to the Rake tasks that run on the servers.

Basically, this allows users to run `cap thinking_sphinx:rebuild INDEX_ONLY=true` and have the `ts:rebuild INDEX_ONLY=true` task run on the servers :smile: 
