### PR TITLE
Specify role for deployment tasks

### DIFF
--- a/lib/thinking_sphinx/capistrano.rb
+++ b/lib/thinking_sphinx/capistrano.rb
@@ -1,29 +1,32 @@
 Capistrano::Configuration.instance(:must_exist).load do
+  _cset(:thinking_sphinx_roles)   { :db }
+  _cset(:thinking_sphinx_options) { {:roles => fetch(:thinking_sphinx_roles)} }
+
   namespace :thinking_sphinx do
     desc 'Generate the Sphinx configuration file.'
-    task :configure do
+    task :configure, fetch(:thinking_sphinx_options) do
       rake 'ts:configure'
     end
 
     desc 'Build Sphinx indexes into the shared path and symlink them into your release.'
-    task :index do
+    task :index, fetch(:thinking_sphinx_options) do
       rake 'ts:index'
     end
     after 'thinking_sphinx:index', 'thinking_sphinx:symlink_indexes'
 
     desc 'Start the Sphinx search daemon.'
-    task :start do
+    task :start, fetch(:thinking_sphinx_options) do
       rake 'ts:start'
     end
     before 'thinking_sphinx:start', 'thinking_sphinx:configure'
 
     desc 'Stop the Sphinx search daemon.'
-    task :stop do
+    task :stop, fetch(:thinking_sphinx_options) do
       rake 'ts:stop'
     end
 
     desc 'Restart the Sphinx search daemon.'
-    task :restart do
+    task :restart, fetch(:thinking_sphinx_options) do
       rake 'ts:stop ts:configure ts:start'
     end
 
@@ -31,19 +34,19 @@ Capistrano::Configuration.instance(:must_exist).load do
 Stop, reindex, and then start the Sphinx search daemon. This task must be executed \
 if you alter the structure of your indexes.
     DESC
-    task :rebuild do
+    task :rebuild, fetch(:thinking_sphinx_options) do
       rake 'ts:rebuild'
     end
     after 'thinking_sphinx:rebuild', 'thinking_sphinx:symlink_indexes'
 
     desc 'Create the shared folder for sphinx indexes.'
-    task :shared_sphinx_folder do
+    task :shared_sphinx_folder, fetch(:thinking_sphinx_options) do
       rails_env = fetch(:rails_env, 'production')
       run "mkdir -p #{shared_path}/db/sphinx/#{rails_env}"
     end
 
     desc 'Symlink Sphinx indexes from the shared folder to the latest release.'
-    task :symlink_indexes do
+    task :symlink_indexes, fetch(:thinking_sphinx_options) do
       run "if [ -d #{release_path} ]; then ln -nfs #{shared_path}/db/sphinx #{release_path}/db/sphinx; else ln -nfs #{shared_path}/db/sphinx #{current_path}/db/sphinx; fi;"
     end
 


### PR DESCRIPTION
It's really hard to perform multi-server deployments with thinking-sphinx.
Everything get's executed on all servers even though sphinx is only running on
one of them. This allows to do the following:

``` ruby
set :thinking_sphinx_roles, :search
require 'thinking_sphinx/capistrano'

server "search.example.com", :rails_app, :search
```
