### PR TITLE
Allow to override excerpt words

### DIFF
--- a/lib/thinking_sphinx/excerpter.rb
+++ b/lib/thinking_sphinx/excerpter.rb
@@ -10,6 +10,7 @@ class ThinkingSphinx::Excerpter
   def initialize(index, words, options = {})
     @index, @words = index, words
     @options = DefaultOptions.merge(options)
+    @words = @options.delete(:words) if @options[:words]
   end
 
   def excerpt!(text)


### PR DESCRIPTION
In thinking-sphinx 2 one could easily override the excerpt words like that:

```
:excerpt_options => {:words => "mywords"}
```

Would be nice if that was supported in thinking-sphinx 3 too:

```
:excerpts => {:words => "mywords"}
```
