### PR TITLE
Respect :limit option on FacetSearch

### DIFF
--- a/lib/thinking_sphinx/facet_search.rb
+++ b/lib/thinking_sphinx/facet_search.rb
@@ -95,13 +95,17 @@ class ThinkingSphinx::FacetSearch
     ThinkingSphinx::Configuration.instance.settings['max_matches'] || 1000
   end
 
+  def limit
+    limit = options[:limit] || options[:per_page] || max_matches
+  end
+
   def options_for(facet)
     options.merge(
       :select      => '*, @groupby, @count',
       :group_by    => facet.name,
       :indices     => index_names_for(facet),
-      :max_matches => max_matches,
-      :limit       => max_matches
+      :max_matches => limit,
+      :limit       => limit
     )
   end
 

--- a/spec/thinking_sphinx/facet_search_spec.rb
+++ b/spec/thinking_sphinx/facet_search_spec.rb
@@ -107,5 +107,17 @@ describe ThinkingSphinx::FacetSearch do
         }
       end
     end
+
+    [:limit, :per_page].each do |setting|
+      it "respects #{setting} option if set" do
+        facet_search = ThinkingSphinx::FacetSearch.new '', {setting => 42}
+
+        facet_search.populate
+
+        batch.searches.each { |search|
+          search.options[setting].should == 42
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR makes it possible for the user to specify a `limit` option on a facet search.

An example use case for this could be getting the 5 authors with the most amount of books:

``` ruby
top_authors = Book.facets(order: '@count desc', limit: 5)[:author]
```

This approach could be useful for showing which artists have the most books with a given query, or similar filters.

---

Semi on-topic: the `order: '@count desc'` option is something that we always use when retrieving facets, as we're mostly interested in getting the facets with the most amount of matches. Wouldn't it make sense to add this option as a default behaviour of facets searches?
