### PR TITLE
Rake ts:index tasks respects --silent option passed to rake

### DIFF
--- a/lib/thinking_sphinx/rake_interface.rb
+++ b/lib/thinking_sphinx/rake_interface.rb
@@ -25,11 +25,11 @@ class ThinkingSphinx::RakeInterface
     end
   end
 
-  def index(reconfigure = true)
+  def index(reconfigure = true, verbose = true)
     configure if reconfigure
     FileUtils.mkdir_p configuration.indices_location
     ThinkingSphinx.before_index_hooks.each { |hook| hook.call }
-    controller.index :verbose => true
+    controller.index :verbose => verbose
   end
 
   def start

--- a/lib/thinking_sphinx/tasks.rb
+++ b/lib/thinking_sphinx/tasks.rb
@@ -6,7 +6,7 @@ namespace :ts do
 
   desc 'Generate the Sphinx configuration file and process all indices'
   task :index => :environment do
-    interface.index(ENV['INDEX_ONLY'] != 'true')
+    interface.index(ENV['INDEX_ONLY'] != 'true', !Rake.application.options.silent)
   end
 
   desc 'Clear out Sphinx files'


### PR DESCRIPTION
Useful for when `ts:index` is called from cron
