### PR TITLE
Indices should always be loaded in the same order

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -68,7 +68,7 @@ class ThinkingSphinx::Configuration < Riddle::Configuration
     return if @preloaded_indices
 
     index_paths.each do |path|
-      Dir["#{path}/**/*.rb"].each do |file|
+      Dir["#{path}/**/*.rb"].sort.each do |file|
         ActiveSupport::Dependencies.require_or_load file
       end
     end


### PR DESCRIPTION
I run into a situation where rails application server loaded indices in a different order than they were indexed in (on a different server). That broke index offset calculation. See:

Rails app server

```
irb(main):001:0> Dir["app/indices/**/*.rb"]
=> ["app/indices/knowledge_base_topic_index.rb", "app/indices/chat_message_index.rb", "app/indices/ticket_index.rb"]
```

offsets:

```
0 -> knowledge_base_topics
1 -> chat_messages
2 -> tickets
```

Util server (used for indexing)

```
irb(main):001:0> Dir["app/indices/**/*.rb"]
=> ["app/indices/knowledge_base_topic_index.rb", "app/indices/ticket_index.rb", "app/indices/chat_message_index.rb"]
```

offsets:

```
0 -> knowledge_base_topics
1 -> tickets
2 -> chat_messages
```
