### PR TITLE
Do not clobber :select option in facet search

### DIFF
--- a/lib/thinking_sphinx/facet_search.rb
+++ b/lib/thinking_sphinx/facet_search.rb
@@ -101,7 +101,7 @@ class ThinkingSphinx::FacetSearch
 
   def options_for(facet)
     options.merge(
-      :select      => '*, @groupby, @count',
+      :select      => (options[:select] || '*') + ', @groupby, @count',
       :group_by    => facet.name,
       :indices     => index_names_for(facet),
       :max_matches => limit,


### PR DESCRIPTION
Facets did not work if using a custom attribute created using :select and then having that attribute used e.g. in :order:

ThinkingSphinx.search('foo', :classes=>[Brand], :select=>'*,@weight as custom_relevance', :order=>'custom_relevance ASC').facets.to_hash
ThinkingSphinx::SphinxError: index brand_core,brand_delta: sort-by attribute 'custom_relevance' not found

After this patch, that works:
irb(main):002:0> ThinkingSphinx.search('foo', :classes=>[Brand], :select=>'*,@weight as custom_relevance', :order=>'custom_relevance ASC').facets.to_hash
=> {:sphinx_internal_class=>{"Brand"=>2}, :owner=>{82=>2}, :class=>{"Brand"=>2}}
