### PR TITLE
Fix utf8 weirdness on tests

### DIFF
--- a/spec/internal/app/indices/city_index.rb
+++ b/spec/internal/app/indices/city_index.rb
@@ -3,4 +3,5 @@ ThinkingSphinx::Index.define :city, :with => :active_record do
   has lat, lng
 
   set_property :charset_table => '0..9, A..Z->a..z, _, a..z, U+410..U+42F->U+430..U+44F, U+430..U+44F, U+0130'
+  set_property :utf8? => true
 end


### PR DESCRIPTION
This is an weird issue that makes the spec with charset fail on TravisCI. This lead to some investigation that the combination of Linux + mysql2 gem does not allow to search/index accented chars completely. Forcing this param on the indices file it fixes the issue.

Also I confirmed that without this option my app on production on a EC2 machine is not able to search accented chars.

Maybe we should also update the documentation?

Fixes #629
