### PR TITLE
Ensure all classes being searched on have an index defined

### DIFF
--- a/lib/thinking_sphinx/active_record/base.rb
+++ b/lib/thinking_sphinx/active_record/base.rb
@@ -16,6 +16,10 @@ module ThinkingSphinx::ActiveRecord::Base
       merge_search ThinkingSphinx.facets, query, options
     end
 
+    def has_sphinx_indices?
+      !sphinx_indices.empty?
+    end
+
     def search(query = nil, options = {})
       merge_search ThinkingSphinx.search, query, options
     end
@@ -28,6 +32,11 @@ module ThinkingSphinx::ActiveRecord::Base
       search = search query, options
       ThinkingSphinx::Search::Merger.new(search).merge! nil, :ids_only => true
     end
+
+    def sphinx_index_names
+      sphinx_indices.map(&:name)
+    end
+
 
     private
 
@@ -51,6 +60,10 @@ module ThinkingSphinx::ActiveRecord::Base
       end
 
       merger.merge! nil, :classes => [self]
+    end
+
+    def sphinx_indices
+      ThinkingSphinx::IndexSet.new([self]).to_a
     end
   end
 end

--- a/lib/thinking_sphinx/errors.rb
+++ b/lib/thinking_sphinx/errors.rb
@@ -39,3 +39,6 @@ end
 
 class ThinkingSphinx::MixedScopesError < StandardError
 end
+
+class ThinkingSphinx::MissingIndexError < StandardError
+end

--- a/lib/thinking_sphinx/index_set.rb
+++ b/lib/thinking_sphinx/index_set.rb
@@ -1,9 +1,9 @@
 class ThinkingSphinx::IndexSet
   include Enumerable
 
-  def initialize(classes, index_names, configuration = nil)
+  def initialize(classes, index_names = nil, configuration = nil)
     @classes       = classes || []
-    @index_names   = index_names
+    @index_names   = index_names || []
     @configuration = configuration || ThinkingSphinx::Configuration.instance
   end
 
@@ -36,7 +36,7 @@ class ThinkingSphinx::IndexSet
 
     return @configuration.indices.select { |index|
       @index_names.include?(index.name)
-    } if @index_names && @index_names.any?
+    } if @index_names.any?
 
     return @configuration.indices if @classes.empty?
 

--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -64,6 +64,7 @@ class ThinkingSphinx::Search < Array
   def populate
     return self if @populated
 
+    enforce_all_classes_have_indices
     middleware.call [context]
     @populated = true
 
@@ -99,6 +100,16 @@ class ThinkingSphinx::Search < Array
   def default_middleware
     options[:ids_only] ? ThinkingSphinx::Middlewares::IDS_ONLY :
       ThinkingSphinx::Middlewares::DEFAULT
+  end
+
+  def enforce_all_classes_have_indices
+    noindex = Array(@options[:classes]).select { |c| !c.has_sphinx_indices? }
+
+    if !noindex.empty?
+      raise ThinkingSphinx::MissingIndexError,
+        "Can't search on a class which doesn't have an index definition. "\
+        "(" + noindex.map(&:name).join(",") + ")"
+    end
   end
 
   def mask_stack

--- a/spec/thinking_sphinx/active_record/base_spec.rb
+++ b/spec/thinking_sphinx/active_record/base_spec.rb
@@ -88,6 +88,12 @@ describe ThinkingSphinx::ActiveRecord::Base do
 
       model.search.options[:order].should be_nil
     end
+
+    it "raises an error on populate if no index has been defined for it" do
+      lambda {
+        model.search.to_a
+      }.should raise_error ThinkingSphinx::MissingIndexError
+    end
   end
 
   describe '.search_count' do
@@ -105,6 +111,37 @@ describe ThinkingSphinx::ActiveRecord::Base do
       model.search_count
 
       search.options[:classes].should == [model]
+    end
+  end
+
+  describe '.has_sphinx_indices?' do
+    it "returns true if an index has been defined for the model" do
+      ThinkingSphinx::Index.define :model, :with => :active_record
+      model.has_sphinx_indices?.should be_true
+      ThinkingSphinx::Configuration.instance.indices.clear
+    end
+
+    it "returns false if no index has been defined for the model" do
+      model.has_sphinx_indices?.should be_false
+    end
+  end
+
+  describe '.sphinx_index_names' do
+    it "returns an array of strings of the model's index names" do
+      ThinkingSphinx::Index.define :model,
+        :with => :active_record,
+        :name => "pancakes"
+
+      ThinkingSphinx::Index.define :model,
+        :with => :active_record,
+        :name => "syrup"
+
+      model.sphinx_index_names.should eq ["pancakes_core", "syrup_core"]
+      ThinkingSphinx::Configuration.instance.indices.clear
+    end
+
+    it "returns an empty array if no index has been defined for the model" do
+      model.sphinx_index_names.should eq []
     end
   end
 end

--- a/spec/thinking_sphinx/search_spec.rb
+++ b/spec/thinking_sphinx/search_spec.rb
@@ -131,6 +131,26 @@ describe ThinkingSphinx::Search do
       search.populate
       search.populate
     end
+
+    it "raises an error if any of the models don't have an index" do
+      model_without_index = Class.new(ActiveRecord::Base) do
+        def self.name; "ModelWithoutIndex"; end
+      end
+
+      model_with_index = Class.new(ActiveRecord::Base) do
+        include ThinkingSphinx::ActiveRecord::Base
+
+        def self.name; "ModelWithIndex"; end
+      end
+
+      ThinkingSphinx::Index.define :model_with_index, :with => :active_record
+
+      lambda {
+        ThinkingSphinx::Search.new(
+          :classes => [model_with_index, model_without_index]).populate
+      }.should raise_error ThinkingSphinx::MissingIndexError,
+        /\(ModelWithoutIndex\)/
+    end
   end
 
   describe '#respond_to?' do


### PR DESCRIPTION
This one has code attached!

When attempting to perform a search on a class without an index, this happens:

```
> Article.search.to_a
NoMethodError: undefined method `options' for nil:NilClass
from .../thinking-sphinx/lib/thinking_sphinx/middlewares/sphinxql.rb:130:in `index_options'
```

That error isn't very helpful. With this patch, a more useful error is raised:

```
> Article.search.to_a
ThinkingSphinx::MissingIndexError: Can't search on a class which doesn't have an index definition. (Article)
from .../thinking-sphinx/lib/thinking_sphinx/search.rb:104:in `enforce_all_classes_have_indices'
```

This doesn't change the behavior, since an error was being raised anyways... just more helpful now.

This code also adds back in two methods from thinking-sphinx v2:
- `ActiveRecord::Base.has_sphinx_indices?` (formerly `has_sphinx_indexes?`) -
  Checks if the class has any indices defined. This method is used when
  enforcing the presence of an index before population.
- `ActiveRecord::Base.sphinx_index_names` - An array of index names for
  this model, eg `["article_core"]`. This method doesn't actually get used
  anywhere else, I just find it useful and feel it goes hand-in-hand with
  `has_sphinx_indices?`.

Finally, a small optimization: the code changes `ThinkingSphinx::IndexSet.new` to only 
require the first argument. The second argument, `index_names`, [gets checked for falsey
anyways](https://github.com/pat/thinking-sphinx/blob/master/lib/thinking_sphinx/index_set.rb#L39), so may as well not require it.
