### PR TITLE
`:with` and `:without` with empty arrays cause SphinxQL error

### DIFF
--- a/spec/acceptance/searching_with_filters_spec.rb
+++ b/spec/acceptance/searching_with_filters_spec.rb
@@ -18,6 +18,16 @@ describe 'Searching with filters', :live => true do
     Book.search(:with => {:year => [2001, 2005]}).to_a.should == [gods, boys]
   end
 
+  it "doesn't limit any results if the array is empty" do
+    gods  = Book.create! :title => 'American Gods',      :year => 2001
+    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
+    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
+    index
+
+    results = Book.search(:with => {:year => []}).to_a.sort
+    results.should == [gods, boys, grave].sort
+  end
+
   it "limits results by a ranged filter" do
     gods  = Book.create! :title => 'American Gods'
     boys  = Book.create! :title => 'Anansi Boys'
@@ -47,6 +57,16 @@ describe 'Searching with filters', :live => true do
     index
 
     Book.search(:without => {:year => [2001, 2005]}).to_a.should == [grave]
+  end
+
+  it "doesn't exclude anything if the :without array is empty" do
+    gods  = Book.create! :title => 'American Gods',      :year => 2001
+    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
+    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
+    index
+
+    results = Book.search(:without => {:year => []}).to_a.sort
+    results.should == [gods, boys, grave].sort
   end
 
   it "limits results by ranged filters on timestamp MVAs" do


### PR DESCRIPTION
- thinking-sphinx 3.0.6 (but this was present in at least 3.0.5 and possibly before)
- sphinx 2.1.2-release

I've attached failing specs as an example.

``` ruby
Book.search(:with => {:year => []}).to_a

ThinkingSphinx::SyntaxError:
     sphinxql: syntax error, unexpected ')', expecting CONST_INT or '-' near ') LIMIT 0, 20; SHOW META'
```

Not sure where the best place is to fix this. @pat, if you can advise, I'll be happy to patch this one up.
