### PR TITLE
fix cjk encoding error

### DIFF
--- a/lib/thinking_sphinx/utf8.rb
+++ b/lib/thinking_sphinx/utf8.rb
@@ -10,7 +10,7 @@ class ThinkingSphinx::UTF8
   end
 
   def encode
-    string.encode!('ISO-8859-1')
+    #string.encode!('ISO-8859-1')
     string.force_encoding('UTF-8')
   end
 end


### PR DESCRIPTION
string.encode!('ISO-8859-1') will cause CJK values encoding error, why need encode to  ISO-8859-1 then UTF8
