### PR TITLE
Issue#668 Blank STI type blows up search with Postgres

### DIFF
--- a/lib/thinking_sphinx/active_record/database_adapters/mysql_adapter.rb
+++ b/lib/thinking_sphinx/active_record/database_adapters/mysql_adapter.rb
@@ -21,6 +21,10 @@ class ThinkingSphinx::ActiveRecord::DatabaseAdapters::MySQLAdapter <
     "IFNULL(#{clause}, #{default})"
   end
 
+  def convert_nulls_or_blank(clause, default = '')
+    "COALESCE(NULLIF(#{clause}, ''), #{default})"
+  end
+
   def group_concatenate(clause, separator = ' ')
     "GROUP_CONCAT(DISTINCT #{clause} SEPARATOR '#{separator}')"
   end

--- a/lib/thinking_sphinx/active_record/database_adapters/postgresql_adapter.rb
+++ b/lib/thinking_sphinx/active_record/database_adapters/postgresql_adapter.rb
@@ -27,6 +27,10 @@ class ThinkingSphinx::ActiveRecord::DatabaseAdapters::PostgreSQLAdapter <
     "COALESCE(#{clause}, #{default})"
   end
 
+  def convert_nulls_or_blank(clause, default = '')
+    "COALESCE(NULLIF(#{clause}, ''), #{default})"
+  end
+
   def group_concatenate(clause, separator = ' ')
     "array_to_string(array_agg(DISTINCT #{clause}), '#{separator}')"
   end

--- a/lib/thinking_sphinx/active_record/sql_source/template.rb
+++ b/lib/thinking_sphinx/active_record/sql_source/template.rb
@@ -33,7 +33,7 @@ class ThinkingSphinx::ActiveRecord::SQLSource::Template
     if inheriting?
       adapter = source.adapter
       quoted_column = "#{adapter.quoted_table_name}.#{adapter.quote(model.inheritance_column)}"
-      source.adapter.convert_nulls quoted_column, "'#{model.sti_name}'"
+      source.adapter.convert_nulls_or_blank quoted_column, "'#{model.sti_name}'"
     else
       "'#{model.name}'"
     end

--- a/spec/acceptance/searching_with_sti_spec.rb
+++ b/spec/acceptance/searching_with_sti_spec.rb
@@ -52,4 +52,11 @@ describe 'Searching across STI models', :live => true do
 
     Bird.search(nil, :skip_sti => true, :classes=>[Bird, FlightlessBird]).to_a.should == [duck, emu]
   end
+
+  it 'finds root objects when type is blank' do
+    animal = Animal.create :name => 'Animal', type: ''
+    index
+
+    Animal.search.to_a.should == [animal]
+  end
 end

--- a/spec/thinking_sphinx/active_record/database_adapters/mysql_adapter_spec.rb
+++ b/spec/thinking_sphinx/active_record/database_adapters/mysql_adapter_spec.rb
@@ -40,6 +40,13 @@ describe ThinkingSphinx::ActiveRecord::DatabaseAdapters::MySQLAdapter do
     end
   end
 
+  describe '#convert_nulls_or_blank' do
+    it "translates arguments to a COALESCE NULLIF SQL call" do
+      adapter.convert_nulls_or_blank('id', 5).should == "COALESCE(NULLIF(id, ''), 5)"
+    end
+  end
+
+
   describe '#group_concatenate' do
     it "group concatenates the clause with the given separator" do
       adapter.group_concatenate('foo', ',').

--- a/spec/thinking_sphinx/active_record/database_adapters/postgresql_adapter_spec.rb
+++ b/spec/thinking_sphinx/active_record/database_adapters/postgresql_adapter_spec.rb
@@ -49,6 +49,12 @@ describe ThinkingSphinx::ActiveRecord::DatabaseAdapters::PostgreSQLAdapter do
     end
   end
 
+  describe '#convert_nulls_or_blank' do
+    it "translates arguments to a COALESCE NULLIF SQL call" do
+      adapter.convert_nulls_or_blank('id', 5).should == "COALESCE(NULLIF(id, ''), 5)"
+    end
+  end
+
   describe '#group_concatenate' do
     it "group concatenates the clause with the given separator" do
       adapter.group_concatenate('foo', ',').

--- a/spec/thinking_sphinx/active_record/sql_source_spec.rb
+++ b/spec/thinking_sphinx/active_record/sql_source_spec.rb
@@ -101,15 +101,15 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
 
     it "uses the inheritance column if it exists for the sphinx class field" do
       adapter.stub :quoted_table_name => '"users"', :quote => '"type"'
-      adapter.stub(:convert_nulls) { |clause, default|
-        "ifnull(#{clause}, #{default})"
+      adapter.stub(:convert_nulls_or_blank) { |clause, default|
+        "coalesce(nullif(#{clause}, ''), #{default})"
       }
       model.stub :column_names => ['type'], :sti_name => 'User'
 
       source.fields.detect { |field|
         field.name == 'sphinx_internal_class_name'
       }.columns.first.__name.
-        should == "ifnull(\"users\".\"type\", 'User')"
+        should == "coalesce(nullif(\"users\".\"type\", ''), 'User')"
     end
   end
 


### PR DESCRIPTION
Use combination of COALESCE and NULLIF to ensure that table rows with
blank string for type are cast to parent class

Note: I needed to use pg 0.15.1 to run specs and also got the following error while running specs:

ThinkingSphinx::SphinxError:
       Using the old-fashion @variables (@count, @weight, etc.) is deprecated
