### PR TITLE
fix total pages count

### DIFF
--- a/lib/thinking_sphinx/masks/pagination_mask.rb
+++ b/lib/thinking_sphinx/masks/pagination_mask.rb
@@ -45,9 +45,9 @@ class ThinkingSphinx::Masks::PaginationMask
   alias_method :count,       :total_entries
 
   def total_pages
-    return 0 if search.meta['total'].nil?
+    return 0 if total_entries.zero?
 
-    @total_pages ||= (search.meta['total'].to_i / search.per_page.to_f).ceil
+    @total_pages ||= (total_entries / search.per_page.to_f).ceil
   end
 
   alias_method :page_count, :total_pages


### PR DESCRIPTION
I got the issue with the `total_pages` method – it returned too few pages for my query. I figured out that it was using `meta['total']` key which in my case had the value 1000 (perhaps a number of bulk fetched rows). But the key `meta['total_found']` had the value 6425 which was an actual number of results that my query should return. 
So, I used the `total_entries` method for counting total pages number because it uses the `meta['total_found']` key.
