### PR TITLE
Update testing documentation

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -48,12 +48,12 @@ module SphinxHelpers
   end
 
   def index_finished?
-    Dir[Rails.root.join(ThinkingSphinx::Test.config.searchd_file_path, '*.{new,tmp}.*')].empty?
+    Dir[Rails.root.join(ThinkingSphinx::Test.config.indices_location, '*.{new,tmp}.*')].empty?
   end
 end
 
 RSpec.configure do |config|
-  config.include SphinxHelpers, type: :request
+  config.include SphinxHelpers, type: :feature
 
   config.before(:suite) do
     # Ensure sphinx directories exist for the test environment
@@ -65,7 +65,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     # Index data when running an acceptance spec.
-    ThinkingSphinx::Test.index if example.metadata[:js]
+    index if example.metadata[:js]
   end
 end
 {% endhighlight %}


### PR DESCRIPTION
Current versions of Thinking Sphinx use `indices_location`, so change the example code to use that instead of `searchd_file_path`.

Also, change the example to use the `index` method defined in `SphinxHelpers`, and use `type: :feature` instead of `type: :request` to reflect current RSpec conventions.

Note: I attempted to make this change through Gyoza's edit function, but it looks like the pull request never actually got created (I waited >10 minutes). I'm recreating it manually here; apologies if it ends up being a duplicate.
