### PR TITLE
Handle jdbc-mysql connection errors

### DIFF
--- a/lib/thinking_sphinx/errors.rb
+++ b/lib/thinking_sphinx/errors.rb
@@ -9,7 +9,7 @@ class ThinkingSphinx::SphinxError < StandardError
       replacement = ThinkingSphinx::SyntaxError.new(error.message)
     when /query error/
       replacement = ThinkingSphinx::QueryError.new(error.message)
-    when /Can't connect to MySQL server/
+    when /Can't connect to MySQL server/, /Communications link failure/
       replacement = ThinkingSphinx::ConnectionError.new(error.message)
     else
       replacement = new(error.message)

--- a/spec/thinking_sphinx/errors_spec.rb
+++ b/spec/thinking_sphinx/errors_spec.rb
@@ -33,6 +33,13 @@ describe ThinkingSphinx::SphinxError do
         should be_a(ThinkingSphinx::ConnectionError)
     end
 
+    it "translates jdbc connection errors" do
+      error.stub :message => "Communications link failure"
+
+      ThinkingSphinx::SphinxError.new_from_mysql(error).
+        should be_a(ThinkingSphinx::ConnectionError)
+    end
+
     it "defaults to sphinx errors" do
       error.stub :message => 'index foo: unknown error: something is wrong'
 


### PR DESCRIPTION
jdbc-mysql raises a different error than mysql2 when it can't connect. This causes jdbc-mysql connection errors not to be mapped to TS::ConnectionError's.

Add a second regex to error map that maps errors with messages matching 'Communications link failure' to a TS::ConnectionError.
