### PR TITLE
Allow to specify which indices to index

### DIFF
--- a/lib/thinking_sphinx/rake_interface.rb
+++ b/lib/thinking_sphinx/rake_interface.rb
@@ -20,11 +20,15 @@ class ThinkingSphinx::RakeInterface
     end
   end
 
-  def index(reconfigure = true, verbose = true)
+  def index(reconfigure = true, indices = nil, verbose = true)
     configure if reconfigure
     FileUtils.mkdir_p configuration.indices_location
     ThinkingSphinx.before_index_hooks.each { |hook| hook.call }
-    controller.index :verbose => verbose
+    if indices.nil?
+      controller.index :verbose => verbose
+    else
+      controller.index indices, :verbose => verbose
+    end
   end
 
   def prepare

--- a/lib/thinking_sphinx/tasks.rb
+++ b/lib/thinking_sphinx/tasks.rb
@@ -8,6 +8,7 @@ namespace :ts do
   task :index => :environment do
     interface.index(
       ENV['INDEX_ONLY'] != 'true',
+      ENV['INDICES'],
       !Rake.application.options.silent
     )
   end


### PR DESCRIPTION
Riddle already has the capability to index only certain indices.
Unfortunately, Thinking Sphinx does not make use of this, so
indexing always happens with `--all`.
This change adds the `INDICES` option to `ts:index`.
When INDICES is set, only the specified indices will get indexed.

Usage example: INDICES="user_core post_core" rake ts:index
