### PR TITLE
Log real-time index updates

### DIFF
--- a/lib/thinking_sphinx.rb
+++ b/lib/thinking_sphinx.rb
@@ -73,6 +73,7 @@ require 'thinking_sphinx/wildcard'
 require 'thinking_sphinx/active_record'
 require 'thinking_sphinx/deltas'
 require 'thinking_sphinx/distributed'
+require 'thinking_sphinx/logger'
 require 'thinking_sphinx/real_time'
 
 require 'thinking_sphinx/railtie' if defined?(Rails)

--- a/lib/thinking_sphinx/logger.rb
+++ b/lib/thinking_sphinx/logger.rb
@@ -1,0 +1,7 @@
+class ThinkingSphinx::Logger
+  def self.log(notification, message, &block)
+    ActiveSupport::Notifications.instrument(
+      "#{notification}.thinking_sphinx", notification => message, &block
+    )
+  end
+end

--- a/lib/thinking_sphinx/middlewares/inquirer.rb
+++ b/lib/thinking_sphinx/middlewares/inquirer.rb
@@ -5,7 +5,7 @@ class ThinkingSphinx::Middlewares::Inquirer <
     @contexts = contexts
     @batch    = nil
 
-    contexts.first.log :query, combined_queries do
+    ThinkingSphinx::Logger.log :query, combined_queries do
       batch.results
     end
 
@@ -52,7 +52,7 @@ class ThinkingSphinx::Middlewares::Inquirer <
       }
 
       total = context[:meta]['total_found']
-      context.log :message, "Found #{total} result#{'s' unless total == 1}"
+      ThinkingSphinx::Logger.log :message, "Found #{total} result#{'s' unless total == 1}"
     end
 
     private

--- a/lib/thinking_sphinx/middlewares/stale_id_filter.rb
+++ b/lib/thinking_sphinx/middlewares/stale_id_filter.rb
@@ -12,7 +12,7 @@ class ThinkingSphinx::Middlewares::StaleIdFilter <
       raise error if @retries <= 0
 
       append_stale_ids error.ids
-      @context.log :message, log_message
+      ThinkingSphinx::Logger.log :message, log_message
 
       @retries -= 1 and retry
     end

--- a/lib/thinking_sphinx/real_time/transcriber.rb
+++ b/lib/thinking_sphinx/real_time/transcriber.rb
@@ -12,9 +12,13 @@ class ThinkingSphinx::RealTime::Transcriber
       values  << property.translate(instance)
     end
 
-    sphinxql = Riddle::Query::Insert.new index.name, columns, values
-    ThinkingSphinx::Connection.take do |connection|
-      connection.execute sphinxql.replace!.to_sql
+    insert = Riddle::Query::Insert.new index.name, columns, values
+    sphinxql = insert.replace!.to_sql
+    
+    ThinkingSphinx::Logger.log :query, sphinxql do
+      ThinkingSphinx::Connection.take do |connection|
+        connection.execute sphinxql
+      end 
     end
   end
 

--- a/lib/thinking_sphinx/search/context.rb
+++ b/lib/thinking_sphinx/search/context.rb
@@ -17,10 +17,4 @@ class ThinkingSphinx::Search::Context
   def []=(key, value)
     @memory[key] = value
   end
-
-  def log(notification, message, &block)
-    ActiveSupport::Notifications.instrument(
-      "#{notification}.thinking_sphinx", notification => message, &block
-    )
-  end
 end

--- a/spec/thinking_sphinx/middlewares/inquirer_spec.rb
+++ b/spec/thinking_sphinx/middlewares/inquirer_spec.rb
@@ -15,10 +15,6 @@ describe ThinkingSphinx::Middlewares::Inquirer do
     :results => [[:raw], [{'Variable_name' => 'meta', 'Value' => 'value'}]]) }
 
   before :each do
-    context.stub(:log) do |notification, message, &block|
-      block.call unless block.nil?
-    end
-
     batch_class = double
     batch_class.stub(:new).and_return(batch_inquirer)
 

--- a/spec/thinking_sphinx/middlewares/stale_id_filter_spec.rb
+++ b/spec/thinking_sphinx/middlewares/stale_id_filter_spec.rb
@@ -15,7 +15,7 @@ describe ThinkingSphinx::Middlewares::StaleIdFilter do
 
   describe '#call' do
     before :each do
-      context.stub :search => search, :log => true
+      context.stub :search => search
     end
 
     context 'one stale ids exception' do


### PR DESCRIPTION
Without logging the REPLACE queries on the real time indices, it was difficult to see if things were being updating as they were supposed to.

This PR adds a log call to `ThinkingSphinx::RealTime::Transcriber#copy`. 

It also extracts the logging logic into a common `ThinkingSphinx::Logger.log` method, which is then used by all objects that need to logging. I'm not entirely sure about this design; maybe a `ThinkingSphinx::Logging` module with a `log` method that gets included on classes that need logging is a better approach. Suggestions are welcomed! :smiley_cat: 
