### PR TITLE
Load configuration settings from the new "common" section.

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -163,8 +163,8 @@ class ThinkingSphinx::Configuration < Riddle::Configuration
   def apply_sphinx_settings!
     [common, indexer, searchd].each do |object|
       settings.each do |key, value|
-        next unless object.class.settings.include?(key.to_sym)
-
+        next unless object.respond_to?("#{key}=")
+        
         object.send("#{key}=", value)
       end
     end


### PR DESCRIPTION
A new "common" section was added to the Sphinx configuration in 2.2.1.
There is a corresponding change to the Riddle repository.

See http://sphinxsearch.com/docs/manual-2.2.1.html#confgroup-common for
more information.
