### PR TITLE
Added respond_to_missing? implementation to ThinkingSphinx::Search

### DIFF
--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -83,12 +83,6 @@ class ThinkingSphinx::Search < Array
     context[:raw]
   end
 
-  def respond_to?(method, include_private = false)
-    super                                        ||
-    results_respond_to?(method, include_private) ||
-    masks_respond_to?(method)
-  end
-
   def to_a
     populate
     context[:results].collect { |result|
@@ -121,14 +115,10 @@ class ThinkingSphinx::Search < Array
     context[:results].send(method, *args, &block)
   end
 
-  def respond_to_missing?(method, include_private)
-    mask_stack.each do |mask|
-      return true if mask.can_handle?(method)
-    end
-
-    populate if !SAFE_METHODS.include?(method.to_s)
-
-    context[:results].respond_to?(method, include_private) || super
+  def respond_to_missing?(method, include_private = false)
+    super ||
+      masks_respond_to?(method) ||
+      results_respond_to?(method, include_private)
   end
 
   def middleware

--- a/spec/thinking_sphinx/search_spec.rb
+++ b/spec/thinking_sphinx/search_spec.rb
@@ -5,6 +5,34 @@ describe ThinkingSphinx::Search do
   let(:context)       { {:results => []} }
   let(:stack)         { double('stack', :call => true) }
 
+  let(:pagination_mask_methods) do
+    [:first_page?,
+     :last_page?,
+     :next_page,
+     :next_page?,
+     :page,
+     :per,
+     :previous_page,
+     :total_entries,
+     :total_count,
+     :count,
+     :total_pages,
+     :page_count,
+     :num_pages]
+  end
+
+  let(:scopes_mask_methods) do
+    [:facets,
+     :search,
+     :search_for_ids]
+  end
+
+  let(:group_enumerator_mask_methods) do
+    [:each_with_count,
+     :each_with_group,
+     :each_with_group_and_count]
+  end
+
   before :each do
     ThinkingSphinx::Search::Context.stub :new => context
 
@@ -143,35 +171,19 @@ describe ThinkingSphinx::Search do
     end
 
     it "should return true for methods delegated to pagination mask by method_missing" do
-      [:first_page?,
-       :last_page?,
-       :next_page,
-       :next_page?,
-       :page,
-       :per,
-       :previous_page,
-       :total_entries,
-       :total_count,
-       :count,
-       :total_pages,
-       :page_count,
-       :num_pages].each do |method|
+      pagination_mask_methods.each do |method|
         expect(search).to respond_to method
       end
     end
 
     it "should return true for methods delegated to scopes mask by method_missing" do
-      [:facets,
-       :search,
-       :search_for_ids].each do |method|
+      scopes_mask_methods.each do |method|
         expect(search).to respond_to method
       end
     end
 
     it "should return true for methods delegated to group enumerators mask by method_missing" do
-      [:each_with_count,
-       :each_with_group,
-       :each_with_group_and_count].each do |method|
+      group_enumerator_mask_methods.each do |method|
         expect(search).to respond_to method
       end
     end
@@ -185,6 +197,14 @@ describe ThinkingSphinx::Search do
       context[:results] << glazed
 
       search.to_a.first.__id__.should == unglazed.__id__
+    end
+  end
+
+  it "correctly handles access to methods delegated to masks through 'method' call" do
+    [pagination_mask_methods,
+     scopes_mask_methods,
+     group_enumerator_mask_methods].flatten.each do |method|
+      expect { search.method method }.to_not raise_exception
     end
   end
 end


### PR DESCRIPTION
... so it correctly says that it responds to methods delegated to masks.

It solves a problem with duck-typing; for example, if you have some code which tries to detect if your object represents a paginated collection by checking `respond_to? :total_entries` result, then it won't realize that ThinkingSphinx::Search object is, in fact, paginated.
