### PR TITLE
Capistrano v3 real-time tasks configuration

### DIFF
--- a/lib/thinking_sphinx/capistrano/v3.rb
+++ b/lib/thinking_sphinx/capistrano/v3.rb
@@ -21,7 +21,7 @@ if you alter the structure of your indexes.
 
   desc 'Stop Sphinx, clear Sphinx index files, generate configuration file, start Sphinx, repopulate all data.'
   task :regenerate do
-    on roles fetch(:thinking_sphinx_options) do
+    on roles fetch(:thinking_sphinx_roles) do
       within current_path do
         with rails_env: fetch(:stage) do
           execute :rake, 'ts:regenerate'
@@ -43,7 +43,7 @@ if you alter the structure of your indexes.
 
   desc 'Generate Sphinx indexes into the shared path.'
   task :generate do
-    on roles fetch(:thinking_sphinx_options) do
+    on roles fetch(:thinking_sphinx_roles) do
       within current_path do
         with rails_env: fetch(:stage) do
           execute :rake, 'ts:generate'


### PR DESCRIPTION
The configuration on the Capistrano v3 real-time tasks that were added in https://github.com/pat/thinking-sphinx/commit/724d9fd958adacf47c31e6b218a03d15341c48d6 still use the cap v2 task configuration value `:thinking_sphinx_options`. 

The rest of the v3 tasks use `:thinking_sphinx_roles`. 

This PR updates the real-time tasks to use `:thinking_sphinx_roles` to be consistent and not require users to duplicate configuration for the same thing.
