### PR TITLE
Fixed: Capistrano v3 tasks configurable rails_env

### DIFF
--- a/lib/thinking_sphinx/capistrano/v3.rb
+++ b/lib/thinking_sphinx/capistrano/v3.rb
@@ -1,6 +1,7 @@
 namespace :load do
   task :defaults do
     set :thinking_sphinx_roles, :db
+    set :thinking_spinx_rails_env, -> { fetch(:stage) }
   end
 end
 
@@ -12,7 +13,7 @@ if you alter the structure of your indexes.
   task :rebuild do
     on roles fetch(:thinking_sphinx_roles) do
       within current_path do
-        with rails_env: fetch(:stage) do
+        with rails_env: fetch(:thinking_spinx_rails_env) do
           execute :rake, "ts:rebuild"
         end
       end
@@ -23,7 +24,7 @@ if you alter the structure of your indexes.
   task :regenerate do
     on roles fetch(:thinking_sphinx_roles) do
       within current_path do
-        with rails_env: fetch(:stage) do
+        with rails_env: fetch(:thinking_spinx_rails_env) do
           execute :rake, 'ts:regenerate'
         end
       end
@@ -34,7 +35,7 @@ if you alter the structure of your indexes.
   task :index do
     on roles fetch(:thinking_sphinx_roles) do
       within current_path do
-        with rails_env: fetch(:stage) do
+        with rails_env: fetch(:thinking_spinx_rails_env) do
           execute :rake, 'ts:index'
         end
       end
@@ -45,7 +46,7 @@ if you alter the structure of your indexes.
   task :generate do
     on roles fetch(:thinking_sphinx_roles) do
       within current_path do
-        with rails_env: fetch(:stage) do
+        with rails_env: fetch(:thinking_spinx_rails_env) do
           execute :rake, 'ts:generate'
         end
       end
@@ -56,7 +57,7 @@ if you alter the structure of your indexes.
   task :restart do
     on roles fetch(:thinking_sphinx_roles) do
       within current_path do
-        with rails_env: fetch(:stage) do
+        with rails_env: fetch(:thinking_spinx_rails_env) do
           %w(stop configure start).each do |task|
             execute :rake, "ts:#{task}"
           end
@@ -69,7 +70,7 @@ if you alter the structure of your indexes.
   task :start do
     on roles fetch(:thinking_sphinx_roles) do
       within current_path do
-        with rails_env: fetch(:stage) do
+        with rails_env: fetch(:thinking_spinx_rails_env) do
           execute :rake, 'ts:start'
         end
       end
@@ -81,7 +82,7 @@ if you alter the structure of your indexes.
   task :configure do
     on roles fetch(:thinking_sphinx_roles) do
       within current_path do
-        with rails_env: fetch(:stage) do
+        with rails_env: fetch(:thinking_spinx_rails_env) do
           execute :rake, 'ts:configure'
         end
       end
@@ -92,7 +93,7 @@ if you alter the structure of your indexes.
   task :stop do
     on roles fetch(:thinking_sphinx_roles) do
       within current_path do
-        with rails_env: fetch(:stage) do
+        with rails_env: fetch(:thinking_spinx_rails_env) do
           execute :rake, 'ts:stop'
         end
       end


### PR DESCRIPTION
I completely bungled #761, so this replaces it.

Currently the cap v3 tasks use the Capistrano stage as the `RAILS_ENV` when executing rake tasks.

My Capistrano v3 `RAILS_ENV` and `:stage` variables do not always match.

This PR allows users to use a new configuration variable `:thinking_spinx_rails_env` which defaults to the value of `:stage` to ensure backwards compatibility while allowing more flexible usage.

For example:

``` ruby
set :stage, 'foo'
set :thinking_spinx_rails_env, 'production'
```
