### PR TITLE
Time Zone setup

### DIFF
--- a/lib/thinking_sphinx/active_record/database_adapters/mysql_adapter.rb
+++ b/lib/thinking_sphinx/active_record/database_adapters/mysql_adapter.rb
@@ -30,7 +30,11 @@ class ThinkingSphinx::ActiveRecord::DatabaseAdapters::MySQLAdapter <
   end
 
   def time_zone_query_pre
-    ["SET TIME_ZONE = '+0:00'"]
+    if ThinkingSphinx::Configuration.instance.settings['time_zone'].blank?
+      ["SET TIME_ZONE = '+0:00'"]
+    else
+      ["SET TIME_ZONE = '#{ThinkingSphinx::Configuration.instance.settings['time_zone']}'"]
+    end
   end
 
   def utf8_query_pre


### PR DESCRIPTION
Add the possibility of define your own Time Zone for MySQL. Just use `config/thinking_sphinx.yml` and add a `time_zone` configuration under your desired environment.
