### PR TITLE
adding compatibility with activerecord-postgis-adapter

### DIFF
--- a/lib/thinking_sphinx/active_record/database_adapters.rb
+++ b/lib/thinking_sphinx/active_record/database_adapters.rb
@@ -23,7 +23,7 @@ module ThinkingSphinx::ActiveRecord::DatabaseAdapters
       case class_name.split('::').last
       when 'MysqlAdapter', 'Mysql2Adapter'
         :mysql
-      when 'PostgreSQLAdapter'
+      when 'PostgreSQLAdapter', 'MainAdapter'
         :postgresql
       when 'JdbcAdapter'
         adapter_type_for_jdbc(model)


### PR DESCRIPTION
https://github.com/rgeo/activerecord-postgis-adapter - this PostGIS adapter uses a different adapter class and should be recognized as Postgresql.
