### PR TITLE
Allow the binlog_path to be set to an empty string

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -91,7 +91,7 @@ class ThinkingSphinx::Configuration < Riddle::Configuration
   end
 
   def render_to_file
-    FileUtils.mkdir_p searchd.binlog_path
+    FileUtils.mkdir_p searchd.binlog_path unless searchd.binlog_path.blank?
 
     open(configuration_file, 'w') { |file| file.write render }
   end

--- a/spec/thinking_sphinx/configuration_spec.rb
+++ b/spec/thinking_sphinx/configuration_spec.rb
@@ -322,6 +322,24 @@ describe ThinkingSphinx::Configuration do
 
       config.render_to_file
     end
+
+    it "creates a directory at the binlog_path" do
+      FileUtils.stub :mkdir_p => true
+      config.stub :searchd => double(:binlog_path => '/path/to/binlog')
+
+      FileUtils.should_receive(:mkdir_p).with('/path/to/binlog')
+
+      config.render_to_file
+    end
+
+    it "skips creating a directory when the binlog_path is blank" do
+      FileUtils.stub :mkdir_p => true
+      config.stub :searchd => double(:binlog_path => '')
+
+      FileUtils.should_not_receive(:mkdir_p)
+
+      config.render_to_file
+    end
   end
 
   describe '#searchd' do


### PR DESCRIPTION
I've recently had trouble with Sphinx failing to start with the following error: 

```
FATAL: binlog: log open error: failed to open /srv/ebth-com/shared/tmp/binlog/production/binlog.001: No such file or directory
```

It appears that Sphinx sees the binlog.meta and binlog.lock files and thinks that there should be a binlog.001 file. According to the [Sphinx documentation](http://sphinxsearch.com/docs/archives/1.10/conf-binlog-path.html), the `binlog_path` is only used for realtime indexing, and in order to disable it, set `binlog_path` to an empty string in the Sphinx conf file.

However, ThinkingSphinx doesn't take a blank string into account when trying to create the directory as a part of the configure process. I simply added a check to the `render_to_file` method.

Thanks to Bryan @railsmachine for helping to diagnose the issue.
