### PR TITLE
Make sure the instance is persisted before trying to get it's id

### DIFF
--- a/lib/thinking_sphinx/real_time/transcriber.rb
+++ b/lib/thinking_sphinx/real_time/transcriber.rb
@@ -4,7 +4,7 @@ class ThinkingSphinx::RealTime::Transcriber
   end
 
   def copy(instance)
-    return unless copy? instance
+    return unless instance.persisted? && copy?(instance)
 
     columns, values = ['id'], [index.document_id_for_key(instance.id)]
     (index.fields + index.attributes).each do |property|


### PR DESCRIPTION
This is for https://github.com/pat/thinking-sphinx/issues/829. If a parent record has an after_save callback for a child index, the child isn't persisted yet, so the index.document_id_for_key(instance.id) throws a nil
