### PR TITLE
Removed local variable / method name clash

### DIFF
--- a/lib/thinking_sphinx/active_record/base.rb
+++ b/lib/thinking_sphinx/active_record/base.rb
@@ -25,8 +25,7 @@ module ThinkingSphinx::ActiveRecord::Base
     end
 
     def search_for_ids(query = nil, options = {})
-      search = search query, options
-      ThinkingSphinx::Search::Merger.new(search).merge! nil, :ids_only => true
+      ThinkingSphinx::Search::Merger.new(search(query, options)).merge! nil, :ids_only => true
     end
 
     private


### PR DESCRIPTION
I'm not sure why it was the way that it was, but it didn't make much sense to me.
