### PR TITLE
Ensure guardfiles are removed even when an exception is raised

### DIFF
--- a/lib/thinking_sphinx/guard/files.rb
+++ b/lib/thinking_sphinx/guard/files.rb
@@ -12,6 +12,9 @@ class ThinkingSphinx::Guard::Files
 
     unlocked.each &:lock
     block.call unlocked.collect(&:name)
+  rescue => error
+    raise error
+  ensure
     unlocked.each &:unlock
   end
 

--- a/spec/acceptance/indexing_spec.rb
+++ b/spec/acceptance/indexing_spec.rb
@@ -24,4 +24,13 @@ describe 'Indexing', :live => true do
 
     FileUtils.rm path
   end
+
+  it "cleans up temp files even when an exception is raised" do
+    FileUtils.mkdir_p Rails.root.join('db/sphinx/test')
+
+    index 'article_core'
+
+    file = Rails.root.join('db/sphinx/test/ts-article_core.tmp')
+    File.exist?(file).should be_false
+  end
 end


### PR DESCRIPTION
I have had intermittent issues with orphaned guard files preventing any delta indexing from happening via Sidekiq. I suspect that Sidekiq jobs are crashing or Sidekiq is restarting due to a deploy, etc. Some delta jobs take more than a few minutes, and Sidekiq only gives running jobs 8 seconds to complete. 

I added an ensure block to the index to force cleanup of the guard files no matter what.
