### PR TITLE
Unlock file only if it's locked

### DIFF
--- a/lib/thinking_sphinx/guard/file.rb
+++ b/lib/thinking_sphinx/guard/file.rb
@@ -21,6 +21,6 @@ class ThinkingSphinx::Guard::File
   end
 
   def unlock
-    FileUtils.rm path
+    FileUtils.rm(path) if locked?
   end
 end


### PR DESCRIPTION
Hi, 
For some reason I've got an error like `Errno::ENOENT: No such file or directory @ unlink_internal -  sphinx/production/ts---all.tmp` while running `rake ts:rebuild`. I guess, I have this uncommon case because of some problems with handling processes, I'll try to figure out why exactly.
However, how do you think, can we make this small fix to avoid the error?