### PR TITLE
Add JSON as a Sphinx type

### DIFF
--- a/lib/thinking_sphinx/active_record/attribute/sphinx_presenter.rb
+++ b/lib/thinking_sphinx/active_record/attribute/sphinx_presenter.rb
@@ -7,7 +7,8 @@ class ThinkingSphinx::ActiveRecord::Attribute::SphinxPresenter
     :string    => :string,
     :bigint    => :bigint,
     :ordinal   => :str2ordinal,
-    :wordcount => :str2wordcount
+    :wordcount => :str2wordcount,
+    :json      => :json
   }
 
   def initialize(attribute, source)

--- a/spec/thinking_sphinx/active_record/sql_source_spec.rb
+++ b/spec/thinking_sphinx/active_record/sql_source_spec.rb
@@ -325,6 +325,15 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
       source.sql_attr_str2wordcount.should include('name')
     end
 
+    it "adds json attributes to sql_attr_json" do
+      source.attributes << double('attribute')
+      presenter.stub :declaration => 'json', :collection_type => :json
+
+      source.render
+
+      source.sql_attr_json.should include('json')
+    end
+
     it "adds relevant settings from thinking_sphinx.yml" do
       config.settings['mysql_ssl_cert'] = 'foo.cert'
       config.settings['morphology']     = 'stem_en' # should be ignored


### PR DESCRIPTION
Sphinx 2.1 added the `sql_attr_json` type, which is not currently supported when generating a TS configuration file. This change just adds the type so that it can be specified in an index.

(I'm not sure if there are more tests that I should have added, so let me know if I missed something)