### PR TITLE
Added missing require

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -1,3 +1,4 @@
+require 'erb'
 require 'pathname'
 
 class ThinkingSphinx::Configuration < Riddle::Configuration


### PR DESCRIPTION
I had a problem configuring TS outside a Rails app. The message was:

```
NameError: uninitialized constant ThinkingSphinx::Configuration::ERB
```

just needed to require 'erb' where it is used to fix the issue.

Thanks