### PR TITLE
Allow for NODETACH option when running `rake ts:start`

### DIFF
--- a/lib/thinking_sphinx/tasks.rb
+++ b/lib/thinking_sphinx/tasks.rb
@@ -39,7 +39,9 @@ namespace :ts do
 
   desc 'Start the Sphinx daemon'
   task :start => :environment do
-    interface.start
+    options = {}
+    options[:nodetach] = true  if ENV['NODETACH'] == 'true'
+    interface.start(options)
   end
 
   desc 'Stop the Sphinx daemon'


### PR DESCRIPTION
Port of #284 to the current version of Thinking Sphinx.

Useful for development when using Foreman to start all the services.

Example usage:

    rake ts:start NODETACH=true