### PR TITLE
Allow primary key to be specified in configuration and not in model

### DIFF
--- a/lib/thinking_sphinx/active_record/sql_source/template.rb
+++ b/lib/thinking_sphinx/active_record/sql_source/template.rb
@@ -48,6 +48,6 @@ class ThinkingSphinx::ActiveRecord::SQLSource::Template
   end
 
   def primary_key
-    source.model.primary_key.to_sym
+    source.options[:primary_key].to_sym
   end
 end

--- a/lib/thinking_sphinx/middlewares/active_record_translator.rb
+++ b/lib/thinking_sphinx/middlewares/active_record_translator.rb
@@ -57,7 +57,7 @@ class ThinkingSphinx::Middlewares::ActiveRecordTranslator <
       @results_for_models ||= model_names.inject({}) do |hash, name|
         model = name.constantize
         hash[name] = model_relation_with_sql_options(model.unscoped).where(
-          model.primary_key => ids_for_model(name)
+          (context.configuration.settings[:primary_key] || model.primary_key || :id) => ids_for_model(name)
         )
 
         hash

--- a/spec/thinking_sphinx/active_record/sql_source_spec.rb
+++ b/spec/thinking_sphinx/active_record/sql_source_spec.rb
@@ -9,7 +9,7 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
   let(:db_config)  { {:host => 'localhost', :user => 'root',
     :database => 'default'} }
   let(:source)     { ThinkingSphinx::ActiveRecord::SQLSource.new(model,
-    :position => 3) }
+    :position => 3, :primary_key => model.primary_key || :id ) }
   let(:adapter)    { double('adapter') }
 
   before :each do
@@ -53,12 +53,14 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
     let(:processor)       { double('processor') }
     let(:source)          {
       ThinkingSphinx::ActiveRecord::SQLSource.new model,
-        :delta_processor => processor_class
+        :delta_processor => processor_class,
+        :primary_key => model.primary_key || :id
     }
     let(:source_with_options)    {
       ThinkingSphinx::ActiveRecord::SQLSource.new model,
         :delta_processor => processor_class,
-        :delta_options   => { :opt_key => :opt_value }
+        :delta_options   => { :opt_key => :opt_value },
+        :primary_key => model.primary_key || :id
     }
 
     it "loads the processor with the adapter" do
@@ -81,7 +83,8 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
   describe '#delta?' do
     it "returns the given delta setting" do
       source = ThinkingSphinx::ActiveRecord::SQLSource.new model,
-        :delta? => true
+        :delta? => true,
+        :primary_key => model.primary_key || :id
 
       source.should be_a_delta
     end
@@ -90,7 +93,8 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
   describe '#disable_range?' do
     it "returns the given range setting" do
       source = ThinkingSphinx::ActiveRecord::SQLSource.new model,
-        :disable_range? => true
+        :disable_range? => true,
+        :primary_key => model.primary_key || :id
 
       source.disable_range?.should be_true
     end
@@ -129,7 +133,7 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
 
     it "allows for custom names, but adds the position suffix" do
       source = ThinkingSphinx::ActiveRecord::SQLSource.new model,
-        :name => 'people', :position => 2
+        :name => 'people', :position => 2, :primary_key => model.primary_key || :id
 
       source.name.should == 'people_2'
     end
@@ -137,7 +141,8 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
 
   describe '#offset' do
     it "returns the given offset" do
-      source = ThinkingSphinx::ActiveRecord::SQLSource.new model, :offset => 12
+      source = ThinkingSphinx::ActiveRecord::SQLSource.new model,
+        :offset => 12, :primary_key => model.primary_key || :id
 
       source.offset.should == 12
     end

--- a/spec/thinking_sphinx/active_record/sql_source_spec.rb
+++ b/spec/thinking_sphinx/active_record/sql_source_spec.rb
@@ -158,6 +158,19 @@ describe ThinkingSphinx::ActiveRecord::SQLSource do
 
       source.options[:utf8?].should be_true
     end
+
+    describe "#primary key" do
+      let(:model)  { double('model', :connection => connection,
+                           :name => 'User', :column_names => [], :inheritance_column => 'type') }
+      let(:source) { ThinkingSphinx::ActiveRecord::SQLSource.new(model,
+                           :position => 3, :primary_key => :custom_key) }
+      let(:template) { ThinkingSphinx::ActiveRecord::SQLSource::Template.new(source) }
+
+      it 'template should allow primary key from options' do
+        template.apply
+        template.source.attributes.collect(&:columns) == :custom_key
+      end
+    end
   end
 
   describe '#render' do

--- a/spec/thinking_sphinx/middlewares/active_record_translator_spec.rb
+++ b/spec/thinking_sphinx/middlewares/active_record_translator_spec.rb
@@ -103,6 +103,18 @@ describe ThinkingSphinx::Middlewares::ActiveRecordTranslator do
       context[:results].should == [instance_1, instance_2]
     end
 
+    it "handles model without primary key" do
+      no_primary_key_model = double('no primary key model')
+      no_primary_key_model.stub :unscoped => no_primary_key_model
+      model_name = double('article', :constantize => no_primary_key_model)
+      instance   = double('instance', :id => 1)
+      no_primary_key_model.stub :where => [instance]
+
+      context[:results] << raw_result(1, model_name)
+
+      middleware.call [context]
+    end
+
     context 'SQL options' do
       let(:relation) { double('relation', :where => []) }
 

--- a/spec/thinking_sphinx/middlewares/active_record_translator_spec.rb
+++ b/spec/thinking_sphinx/middlewares/active_record_translator_spec.rb
@@ -11,9 +11,10 @@ describe ThinkingSphinx::Middlewares::ActiveRecordTranslator do
   let(:app)        { double('app', :call => true) }
   let(:middleware) {
     ThinkingSphinx::Middlewares::ActiveRecordTranslator.new app }
-  let(:context)    { {:raw => [], :results => []} }
+  let(:context)    { {:raw => [], :results => [] } }
   let(:model)      { double('model', :primary_key => :id) }
   let(:search)     { double('search', :options => {}) }
+  let(:configuration) { double('configuration', :settings => {:primary_key => :id}) }
 
   def raw_result(id, model_name)
     {'sphinx_internal_id' => id, 'sphinx_internal_class' => model_name}
@@ -22,6 +23,7 @@ describe ThinkingSphinx::Middlewares::ActiveRecordTranslator do
   describe '#call' do
     before :each do
       context.stub :search => search
+      context.stub :configuration => configuration
       model.stub :unscoped => model
     end
 


### PR DESCRIPTION
Most of the time the attached database will have a primary key defined - however I had a case where there was a large database, with an index marked as primary but not actually an index called PRIMARY. Because the database was being constantly added to it wasn't feasible to reindex (which requires locking).

I should have been able to specify the primary index in the configuration but this didn't filter through to all parts of the code.

As seen [here](https://github.com/pat/thinking-sphinx/blob/master/lib/thinking_sphinx/active_record/index.rb#L66) the configuration value should be used first, followed by the model/database value, and finally just use :id if neither of the other two exist. The attached changes just use this logic in the two other places it seemed to be missing.