### PR TITLE
add rand_seed to SELECT_OPTIONS

### DIFF
--- a/lib/thinking_sphinx/middlewares/sphinxql.rb
+++ b/lib/thinking_sphinx/middlewares/sphinxql.rb
@@ -4,7 +4,7 @@ class ThinkingSphinx::Middlewares::SphinxQL <
   SELECT_OPTIONS = [:agent_query_timeout, :boolean_simplify, :comment, :cutoff,
     :field_weights, :global_idf, :idf, :index_weights, :max_matches,
     :max_query_time, :max_predicted_time, :ranker, :retry_count, :retry_delay,
-    :reverse_scan, :sort_method]
+    :reverse_scan, :sort_method, :rand_seed]
 
   def call(contexts)
     contexts.each do |context|


### PR DESCRIPTION
sphinx now support passing a seed to order `rand()`
but it has to be passed as a separate option so it has been added to
the SELECT_OPTIONS list

I'm not sure if a test is needed for this I looked for one for `comment` and wasn't able to find it


thanks!

[sphinx docs on rand seed](http://sphinxsearch.com/docs/current/sphinxql-select.html)