### PR TITLE
Reduce allocations in ActiveRecord callbacks

### DIFF
--- a/lib/thinking_sphinx/active_record/association_proxy/attribute_finder.rb
+++ b/lib/thinking_sphinx/active_record/association_proxy/attribute_finder.rb
@@ -29,7 +29,7 @@ class ThinkingSphinx::ActiveRecord::AssociationProxy::AttributeFinder
     @indices ||= begin
       configuration.preload_indices
       configuration.indices_for_references(
-        *@association.klass.name.underscore.to_sym
+        *ThinkingSphinx::IndexSet.reference_name(@association.klass)
       ).reject &:distributed?
     end
   end

--- a/lib/thinking_sphinx/active_record/callbacks/update_callbacks.rb
+++ b/lib/thinking_sphinx/active_record/callbacks/update_callbacks.rb
@@ -35,7 +35,7 @@ class ThinkingSphinx::ActiveRecord::Callbacks::UpdateCallbacks <
   end
 
   def reference
-    instance.class.name.underscore.to_sym
+    ThinkingSphinx::IndexSet.reference_name(instance.class)
   end
 
   def update(index)

--- a/lib/thinking_sphinx/index_set.rb
+++ b/lib/thinking_sphinx/index_set.rb
@@ -1,5 +1,9 @@
 class ThinkingSphinx::IndexSet
   include Enumerable
+  
+  def self.reference_name(klass)
+    klass.name.underscore.to_sym
+  end
 
   delegate :each, :empty?, :to => :indices
 
@@ -63,7 +67,7 @@ class ThinkingSphinx::IndexSet
 
   def references
     options[:references] || classes_and_ancestors.collect { |klass|
-      klass.name.underscore.to_sym
+      ThinkingSphinx::IndexSet.reference_name(klass)
     }
   end
 

--- a/lib/thinking_sphinx/index_set.rb
+++ b/lib/thinking_sphinx/index_set.rb
@@ -2,7 +2,8 @@ class ThinkingSphinx::IndexSet
   include Enumerable
   
   def self.reference_name(klass)
-    klass.name.underscore.to_sym
+    @cached_results ||= {}
+    @cached_results[klass.name] ||= klass.name.underscore.to_sym
   end
 
   delegate :each, :empty?, :to => :indices

--- a/lib/thinking_sphinx/middlewares/sphinxql.rb
+++ b/lib/thinking_sphinx/middlewares/sphinxql.rb
@@ -82,7 +82,7 @@ class ThinkingSphinx::Middlewares::SphinxQL <
 
     def indices_match_classes?
       indices.collect(&:reference).uniq.sort == classes.collect { |klass|
-        klass.name.underscore.to_sym
+        ThinkingSphinx::IndexSet.reference_name(klass)
       }.sort
     end
 


### PR DESCRIPTION
In our app, IndexSet#references is called 54 times each time a model is saved.  This calls ActiveSupport's `underscore` method, which is relatively expensive and is responsible for a large chunk of object allocations.

This PR moves all instances of `klass.name.underscore.to_sym` to a common `IndexSet.reference_name` method, then caches the result.   WDYT?