### PR TITLE
Change from find_each to find_in_batches to allow a bulk replace into command

### DIFF
--- a/lib/thinking_sphinx/real_time/populator.rb
+++ b/lib/thinking_sphinx/real_time/populator.rb
@@ -12,9 +12,9 @@ class ThinkingSphinx::RealTime::Populator
 
     remove_files
 
-    scope.find_each do |instance|
-      transcriber.copy instance
-      instrument 'populated', :instance => instance
+    scope.find_in_batches do |instances|
+      transcriber.copy instances
+      instrument 'populated', :instance => instances
     end
 
     controller.rotate

--- a/spec/thinking_sphinx/real_time/callbacks/real_time_callbacks_spec.rb
+++ b/spec/thinking_sphinx/real_time/callbacks/real_time_callbacks_spec.rb
@@ -33,7 +33,7 @@ describe ThinkingSphinx::RealTime::Callbacks::RealTimeCallbacks do
 
     it "creates an insert statement with all fields and attributes" do
       Riddle::Query::Insert.should_receive(:new).
-        with('my_index', ['id', 'name', 'created_at'], [123, 'Foo', time]).
+        with('my_index', ['id', 'name', 'created_at'], [[123, 'Foo', time]]).
         and_return(insert)
 
       callbacks.after_save instance
@@ -62,7 +62,7 @@ describe ThinkingSphinx::RealTime::Callbacks::RealTimeCallbacks do
 
       it "creates an insert statement with all fields and attributes" do
         Riddle::Query::Insert.should_receive(:new).
-          with('my_index', ['id', 'name', 'created_at'], [123, 'Foo', time]).
+          with('my_index', ['id', 'name', 'created_at'], [[123, 'Foo', time]]).
           and_return(insert)
 
         callbacks.after_save instance
@@ -94,7 +94,7 @@ describe ThinkingSphinx::RealTime::Callbacks::RealTimeCallbacks do
 
       it "creates insert statements with all fields and attributes" do
         Riddle::Query::Insert.should_receive(:new).twice.
-          with('my_index', ['id', 'name', 'created_at'], [123, 'Foo', time]).
+          with('my_index', ['id', 'name', 'created_at'], [[123, 'Foo', time]]).
           and_return(insert)
 
         callbacks.after_save instance
@@ -128,7 +128,7 @@ describe ThinkingSphinx::RealTime::Callbacks::RealTimeCallbacks do
 
       it "creates insert statements with all fields and attributes" do
         Riddle::Query::Insert.should_receive(:new).twice.
-          with('my_index', ['id', 'name', 'created_at'], [123, 'Foo', time]).
+          with('my_index', ['id', 'name', 'created_at'], [[123, 'Foo', time]]).
           and_return(insert)
 
         callbacks.after_save instance


### PR DESCRIPTION
Doing a generate on a large dataset takes a long time. While looking into improvements, I noticed the actual sphinx query is a single insert/replace for every record, which would lead to lots and lots of commands being run. I've switched it to use find_in_batches which will yield batches of instances to the transcriber which can then utilize the fact that the Riddle Insert will handle inserting multiple records in one command.

I didn't really see any tests handling this case, nor many for the transcriber, so I just got the existing tests to work by having them expect an array of values (even though it was just one value set). I'm sure there should be more/better tests, but I'm not too familiar with the test suite to write it all up.

The end goal is that the command that gets run by the generate is:

```ruby
REPLACE INTO index (columns) VALUES (values), (values), (values);
```

and the standard callbacks should still run:

```ruby
REPLACE INTO index(columns) VALUES (values);
```

I'm not sure what the actual performance gain will be on large data sets, but on my local data set I still see an improvement over the multiple inserts. I plan on trying to find time to test it on a bigger data set, but wanted to get this out to get reviewed and opinions/thoughts on it as soon as possible.

One thing I also wasn't too sure about was if making the statement have multiple values would cause any limits to be hit as I think there is a MySQL insert character limit.