### PR TITLE
Fix StaleId handling with multiple contexts

### DIFF
--- a/lib/thinking_sphinx/middlewares/stale_id_checker.rb
+++ b/lib/thinking_sphinx/middlewares/stale_id_checker.rb
@@ -33,7 +33,7 @@ class ThinkingSphinx::Middlewares::StaleIdChecker <
     end
 
     def raise_exception
-      raise ThinkingSphinx::Search::StaleIdsException, stale_ids
+      raise ThinkingSphinx::Search::StaleIdsException.new(stale_ids, context)
     end
 
     def stale_ids

--- a/lib/thinking_sphinx/middlewares/stale_id_filter.rb
+++ b/lib/thinking_sphinx/middlewares/stale_id_filter.rb
@@ -11,7 +11,7 @@ class ThinkingSphinx::Middlewares::StaleIdFilter <
     rescue ThinkingSphinx::Search::StaleIdsException => error
       raise error if @retries <= 0
 
-      append_stale_ids error.ids
+      append_stale_ids error.ids, error.context
       ThinkingSphinx::Logger.log :message, log_message
 
       @retries -= 1 and retry
@@ -20,7 +20,7 @@ class ThinkingSphinx::Middlewares::StaleIdFilter <
 
   private
 
-  def append_stale_ids(ids)
+  def append_stale_ids(ids, context)
     @stale_ids |= ids
 
     context.search.options[:without_ids] ||= []

--- a/lib/thinking_sphinx/search/stale_ids_exception.rb
+++ b/lib/thinking_sphinx/search/stale_ids_exception.rb
@@ -1,8 +1,9 @@
 class ThinkingSphinx::Search::StaleIdsException < StandardError
-  attr_reader :ids
+  attr_reader :ids, :context
 
-  def initialize(ids)
+  def initialize(ids, context)
     @ids = ids
+    @context = context
   end
 
   def message

--- a/spec/thinking_sphinx/middlewares/stale_id_checker_spec.rb
+++ b/spec/thinking_sphinx/middlewares/stale_id_checker_spec.rb
@@ -41,6 +41,7 @@ describe ThinkingSphinx::Middlewares::StaleIdChecker do
         middleware.call [context]
       }.should raise_error(ThinkingSphinx::Search::StaleIdsException) { |err|
         err.ids.should == [42]
+        err.context.should == context
       }
     end
   end

--- a/spec/thinking_sphinx/middlewares/stale_id_filter_spec.rb
+++ b/spec/thinking_sphinx/middlewares/stale_id_filter_spec.rb
@@ -23,7 +23,7 @@ describe ThinkingSphinx::Middlewares::StaleIdFilter do
         app.stub(:call) do
           @calls ||= 0
           @calls += 1
-          raise ThinkingSphinx::Search::StaleIdsException, [12] if @calls == 1
+          raise ThinkingSphinx::Search::StaleIdsException.new([12], context) if @calls == 1
         end
       end
 
@@ -47,8 +47,8 @@ describe ThinkingSphinx::Middlewares::StaleIdFilter do
         app.stub(:call) do
           @calls ||= 0
           @calls += 1
-          raise ThinkingSphinx::Search::StaleIdsException, [12] if @calls == 1
-          raise ThinkingSphinx::Search::StaleIdsException, [13] if @calls == 2
+          raise ThinkingSphinx::Search::StaleIdsException.new([12], context) if @calls == 1
+          raise ThinkingSphinx::Search::StaleIdsException.new([13], context) if @calls == 2
         end
       end
 
@@ -73,9 +73,9 @@ describe ThinkingSphinx::Middlewares::StaleIdFilter do
           @calls ||= 0
           @calls += 1
 
-          raise ThinkingSphinx::Search::StaleIdsException, [12] if @calls == 1
-          raise ThinkingSphinx::Search::StaleIdsException, [13] if @calls == 2
-          raise ThinkingSphinx::Search::StaleIdsException, [14] if @calls == 3
+          raise ThinkingSphinx::Search::StaleIdsException.new([12], context) if @calls == 1
+          raise ThinkingSphinx::Search::StaleIdsException.new([13], context) if @calls == 2
+          raise ThinkingSphinx::Search::StaleIdsException.new([14], context) if @calls == 3
         end
       end
 
@@ -87,5 +87,25 @@ describe ThinkingSphinx::Middlewares::StaleIdFilter do
         }
       end
     end
+
+    context  'stale ids exceptions with multiple contexts' do
+      let(:context2) { {:raw => [], :results => []} }
+      let(:search2) { double('search2', :options => {}) }
+      before :each do
+        context2.stub :search => search2
+        app.stub(:call) do
+          @calls ||= 0
+          @calls += 1
+          raise ThinkingSphinx::Search::StaleIdsException.new([12], context2) if @calls == 1
+        end
+      end
+
+      it "appends the ids to the without_ids filter in the correct context" do
+        middleware.call [context, context2]
+        search.options[:without_ids].should == nil
+        search2.options[:without_ids].should == [12]
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Prior to this, BatchedSearches with multiple contexts would append stale ids to the first context, rather than the context which was actually missing them, and so the retried attempts would also fail.  WDYT?