### PR TITLE
configuration.settings are always strings, not symbols

### DIFF
--- a/lib/thinking_sphinx/middlewares/active_record_translator.rb
+++ b/lib/thinking_sphinx/middlewares/active_record_translator.rb
@@ -49,7 +49,7 @@ class ThinkingSphinx::Middlewares::ActiveRecordTranslator <
 
     def result_for(row)
       results_for_models[row['sphinx_internal_class']].detect { |record|
-        record.id == row['sphinx_internal_id']
+        record.public_send(context.configuration.settings['primary_key'] || model.primary_key || :id) == row['sphinx_internal_id']
       }
     end
 

--- a/lib/thinking_sphinx/middlewares/active_record_translator.rb
+++ b/lib/thinking_sphinx/middlewares/active_record_translator.rb
@@ -57,7 +57,7 @@ class ThinkingSphinx::Middlewares::ActiveRecordTranslator <
       @results_for_models ||= model_names.inject({}) do |hash, name|
         model = name.constantize
         hash[name] = model_relation_with_sql_options(model.unscoped).where(
-          (context.configuration.settings[:primary_key] || model.primary_key || :id) => ids_for_model(name)
+          (context.configuration.settings['primary_key'] || model.primary_key || :id) => ids_for_model(name)
         )
 
         hash

--- a/lib/thinking_sphinx/middlewares/active_record_translator.rb
+++ b/lib/thinking_sphinx/middlewares/active_record_translator.rb
@@ -49,7 +49,7 @@ class ThinkingSphinx::Middlewares::ActiveRecordTranslator <
 
     def result_for(row)
       results_for_models[row['sphinx_internal_class']].detect { |record|
-        record.public_send(context.configuration.settings['primary_key'] || model.primary_key || :id) == row['sphinx_internal_id']
+        record.public_send(context.configuration.settings['primary_key'] || :id) == row['sphinx_internal_id']
       }
     end
 


### PR DESCRIPTION
After struggling to find why this configuration wasn't being applied, I found that it was loading from a symbol, meanwhile thinking_sphinx.yml's loaded variables were being treated as strings.