### PR TITLE
Don't resume delta indexing if was suspended

### DIFF
--- a/lib/thinking_sphinx/deltas.rb
+++ b/lib/thinking_sphinx/deltas.rb
@@ -21,12 +21,16 @@ module ThinkingSphinx::Deltas
   end
 
   def self.suspend(reference, &block)
+    was_suspended = suspended?
     suspend!
     yield
-    resume!
 
-    config.indices_for_references(reference).each do |index|
-      index.delta_processor.index index if index.delta?
+    unless was_suspended
+      resume!
+
+      config.indices_for_references(reference).each do |index|
+        index.delta_processor.index index if index.delta?
+      end
     end
   end
 


### PR DESCRIPTION
WIP

This is an experimental commit to get input from @pat on whether it's a good direction or not.  

The issue I'm facing is that in my test_helper I call `ThinkingSphinx::Deltas.suspend!` because it's super noisy and I don't need to test any of this behavior specifically.  But there is also a place in the code where I defer delta indexing for performance with `ThinkingSphinx::Deltas.suspend(:index)`.  The problem is that when a test hits that then delta indexing is re-enabled.

I can fix this in the code level, but it's a fairly nasty intrusion of testing concerns into application code.

This solution is a bit ugly, and doesn't take into account `suspend_and_update` at all.  Do you think it's viable?  If so I can further refine it, or if you think not I can consider other solutions.