### PR TITLE
Fix SLE-11 MySQL error handling

### DIFF
--- a/lib/thinking_sphinx/errors.rb
+++ b/lib/thinking_sphinx/errors.rb
@@ -9,7 +9,7 @@ class ThinkingSphinx::SphinxError < StandardError
       replacement = ThinkingSphinx::SyntaxError.new(error.message)
     when /query error/
       replacement = ThinkingSphinx::QueryError.new(error.message)
-    when /Can't connect to MySQL server/, /Communications link failure/
+    when /Can't connect to MySQL server/, /Communications link failure/, /Lost connection to MySQL server/
       replacement = ThinkingSphinx::ConnectionError.new(
         "Error connecting to Sphinx via the MySQL protocol. #{error.message}"
       )


### PR DESCRIPTION
In SUSE's SLE-11 MySQL package, it can happen that the MySQL server responds with "Lost connection to MySQL server". This should be handled in the code.

We're currently patching this manually during package building: https://build.opensuse.org/package/view_file/devel:languages:ruby:extensions/rubygem-thinking-sphinx/SLE-11-mysql-error.patch?expand=1

It would be nice to get this in your code base, so we do not need this patch anymore to support SLES-11 (SUSE Linux Enterprise Server 11)