### PR TITLE
Enhancement: Add `where` to the `sql` options

### DIFF
--- a/lib/thinking_sphinx/middlewares/active_record_translator.rb
+++ b/lib/thinking_sphinx/middlewares/active_record_translator.rb
@@ -91,6 +91,7 @@ class ThinkingSphinx::Middlewares::ActiveRecordTranslator <
       relation = relation.order  sql_options[:order]  if sql_options[:order]
       relation = relation.select sql_options[:select] if sql_options[:select]
       relation = relation.group  sql_options[:group]  if sql_options[:group]
+      relation = relation.where  sql_options[:where]  if sql_options[:where]
       relation
     end
 

--- a/spec/thinking_sphinx/middlewares/active_record_translator_spec.rb
+++ b/spec/thinking_sphinx/middlewares/active_record_translator_spec.rb
@@ -167,6 +167,15 @@ describe ThinkingSphinx::Middlewares::ActiveRecordTranslator do
 
         middleware.call [context]
       end
+
+      it "passes through SQL where options to the relation" do
+        search.options[:sql] = {:where => "deleted_at IS NULL"}
+
+        expect(relation).to receive(:where).with("deleted_at IS NULL").and_return(relation)
+
+        middleware.call [context]
+      end
+
     end
   end
 end


### PR DESCRIPTION
Usecase:
We're working with a `deleted_at` flag in our database and would
like to use this to filter out (soft) deleted rows with:

`sql: {where: "deleted_at IS NULL"}`

note: maybe rename the `sql` option to `arel_options`? makes it's usage more clear