### PR TITLE
Support Octopus gem's Octopus::ProxyConfig

### DIFF
--- a/lib/thinking_sphinx/active_record/sql_source.rb
+++ b/lib/thinking_sphinx/active_record/sql_source.rb
@@ -14,7 +14,7 @@ module ThinkingSphinx
 
       def initialize(model, options = {})
         @model             = model
-        @database_settings = model.connection.instance_variable_get(:@config).clone
+        @database_settings = model.connection.respond_to?(:config) ? model.connection.config.clone : model.connection.instance_variable_get(:@config).clone
         @options           = {
           :utf8? => (@database_settings[:encoding].to_s[/^utf8/])
         }.merge options


### PR DESCRIPTION
@pat 

On Octopus 0.9.x the `model.connection` method doesn't return a normal `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter` (or whatever is configured). Instead a `Octopus::ProxyConfig` is returned which proxies a lot of the functionality.

In this case, `@config` instance variable is not guaranteed to exist. We need to check for this.

Let me know if you have a better idea for addressing this problem.