### PR TITLE
sql_options defined per model

### DIFF
--- a/lib/thinking_sphinx/middlewares/active_record_translator.rb
+++ b/lib/thinking_sphinx/middlewares/active_record_translator.rb
@@ -77,7 +77,9 @@ class ThinkingSphinx::Middlewares::ActiveRecordTranslator <
       @results_for_models ||= model_names.inject({}) do |hash, name|
         model = name.constantize
 
-        hash[name] = model_relation_with_sql_options(model.unscoped).where(
+        model_sql_options = sql_options[name] || sql_options
+
+        hash[name] = model_relation_with_sql_options(model.unscoped, model_sql_options).where(
           primary_key_for(model) => ids_for_model(name)
         )
 
@@ -85,12 +87,12 @@ class ThinkingSphinx::Middlewares::ActiveRecordTranslator <
       end
     end
 
-    def model_relation_with_sql_options(relation)
-      relation = relation.includes sql_options[:include] if sql_options[:include]
-      relation = relation.joins  sql_options[:joins]  if sql_options[:joins]
-      relation = relation.order  sql_options[:order]  if sql_options[:order]
-      relation = relation.select sql_options[:select] if sql_options[:select]
-      relation = relation.group  sql_options[:group]  if sql_options[:group]
+    def model_relation_with_sql_options(relation, model_sql_options)
+      relation = relation.includes model_sql_options[:include] if model_sql_options[:include]
+      relation = relation.joins  model_sql_options[:joins]  if model_sql_options[:joins]
+      relation = relation.order  model_sql_options[:order]  if model_sql_options[:order]
+      relation = relation.select model_sql_options[:select] if model_sql_options[:select]
+      relation = relation.group  model_sql_options[:group]  if model_sql_options[:group]
       relation
     end
 

--- a/spec/thinking_sphinx/middlewares/active_record_translator_spec.rb
+++ b/spec/thinking_sphinx/middlewares/active_record_translator_spec.rb
@@ -119,11 +119,11 @@ describe ThinkingSphinx::Middlewares::ActiveRecordTranslator do
 
     context 'SQL options' do
       let(:relation) { double('relation', :where => []) }
+      let(:model_name) { double('article', :constantize => model) }
 
       before :each do
         allow(model).to receive_messages :unscoped => relation
 
-        model_name = double('article', :constantize => model)
         context[:results] << raw_result(1, model_name)
       end
 
@@ -164,6 +164,14 @@ describe ThinkingSphinx::Middlewares::ActiveRecordTranslator do
         search.options[:sql] = {:group => :column}
 
         expect(relation).to receive(:group).with(:column).and_return(relation)
+
+        middleware.call [context]
+      end
+
+      it "passes through SQL options defined by model to the relation" do
+        search.options[:sql] = {model_name => {:joins => :association}}
+
+        expect(relation).to receive(:joins).with(:association).and_return(relation)
 
         middleware.call [context]
       end


### PR DESCRIPTION
When multiple indices defined in search it becomes almost impossible to define sql includes. Different models has different relations usually

```ruby
class City < ApplicationRecord
  has_one :overall_stat
  belongs_to :country
end

class Country < ApplicationRecord
  has_many :cities
end
```

This woudn't work
```ruby
ThinkingSphinx.search("*", indices: %w(country_core city_core), sql: {include: [:overall_stat, :country]})
```

I suggest to define ```:sql``` option in the following maner (with fallback to previous variant):
```ruby
ThinkingSphinx.search("*", indices: %w(country_core city_core), sql: {'City' => {include: [:overall_stat, :country]}})
```
