### PR TITLE
Fix respond_to with scopes

### DIFF
--- a/lib/thinking_sphinx/scopes.rb
+++ b/lib/thinking_sphinx/scopes.rb
@@ -26,5 +26,9 @@ module ThinkingSphinx::Scopes
       query, options = sphinx_scopes[method].call(*args)
       search query, (options || {})
     end
+
+    def respond_to_missing?(method, include_private = false)
+      super || sphinx_scopes.keys.include?(method)
+    end
   end
 end

--- a/spec/thinking_sphinx/scopes_spec.rb
+++ b/spec/thinking_sphinx/scopes_spec.rb
@@ -18,6 +18,10 @@ describe ThinkingSphinx::Scopes do
       model.sphinx_scopes[:foo] = Proc.new { {:with => {:foo => :bar}} }
     end
 
+    it "implements respond_to" do
+      expect(model).to respond_to(:foo)
+    end
+
     it "creates new search" do
       expect(model.foo.class).to eq(ThinkingSphinx::Search)
     end


### PR DESCRIPTION
I ran into problems trying to stub out sphinx scopes with rspec:

```ruby
class Post
  sphinx_scope :public_posts, -> { { with: {public_read: true } }
end

allow(Post).to receive(:public_posts).and_return(double('sphinx-results'))
``` 
which raises "Post does not implement: public_posts".  WDYT to this fix?
