### PR TITLE
Use require_or_load also with Rails 5

### DIFF
--- a/lib/thinking_sphinx/configuration.rb
+++ b/lib/thinking_sphinx/configuration.rb
@@ -98,7 +98,7 @@ class ThinkingSphinx::Configuration < Riddle::Configuration
   end
 
   def preload_index(file)
-    if ActiveRecord::VERSION::MAJOR < 5
+    if ActiveRecord::VERSION::MAJOR <= 5
       ActiveSupport::Dependencies.require_or_load file
     else
       load file


### PR DESCRIPTION
In ed37e9e6a9 `require_or_load` was used again for Rails 3 and 4. This commit uses it also for Rails 5, as it was working before.

See https://github.com/pat/thinking-sphinx/issues/764#issuecomment-509682185.