### PR TITLE
[Debug] Logging info that table does not exist for a model

### DIFF
--- a/lib/thinking_sphinx/core/index.rb
+++ b/lib/thinking_sphinx/core/index.rb
@@ -38,7 +38,11 @@ module ThinkingSphinx::Core::Index
   end
 
   def interpret_definition!
-    return unless model.table_exists?
+    table_exists = model.table_exists?
+    unless table_exists
+      Rails.logger.info "No table exists for #{model}. Index can not be created" 
+      return
+    end
     return if @interpreted_definition
 
     apply_defaults!


### PR DESCRIPTION
I have spend about 3 hours debugging a test instance to identify this problem. Although it is not a major issue I think
it could save a lot of time.

Summary is the following:
1. Table does not exists
2. rake ts:index returns a very strange error connected with configuration
3. There is nothing wrong in the configuration and the same configuration is working on other app instances.
4. For this particulare app instance a certain table is missing.
5. Because of the missing table no configuration could be generated and the error is that there is something wrong with the index
6. Contrary there is nothing wrong with the index. It is just not existing, because it can not be generated and the reason why it can not be generated is difficult to identify at first.

Details are the following.

When there is no table for the index a very strange error occurs. This error is

````
Riddle::Configuration::ConfigurationError: course_core [] /Build_fllcasts/workspace/db/sphinx/development/course_core
/usr/local/rvm/gems/ruby-2.4.6/gems/riddle-2.3.2/lib/riddle/configuration/index.rb:26:in `render'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/core/index.rb:71:in `render'
/usr/local/rvm/gems/ruby-2.4.6/gems/riddle-2.3.2/lib/riddle/configuration.rb:45:in `block in render'
/usr/local/rvm/gems/ruby-2.4.6/gems/riddle-2.3.2/lib/riddle/configuration.rb:45:in `collect'
/usr/local/rvm/gems/ruby-2.4.6/gems/riddle-2.3.2/lib/riddle/configuration.rb:45:in `render'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration.rb:111:in `render'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration.rb:119:in `block in render_to_file'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration.rb:119:in `render_to_file'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/commands/configure.rb:7:in `call'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/commands/base.rb:11:in `call_with_handling'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/commands/base.rb:7:in `call'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/commander.rb:7:in `call'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/interfaces/base.rb:9:in `command'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/interfaces/sql.rb:25:in `index'
/usr/local/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/tasks.rb:49:in `block (3 levels) in <top (required)>'
/usr/local/rvm/gems/ruby-2.4.6/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.4.6/bin/ruby_executable_hooks:24:in `eval'
/usr/local/rvm/gems/ruby-2.4.6/bin/ruby_executable_hooks:24:in `<main>'

````

This error occurs at a very late stage. It is because the method append_source was not called and no sources were appended
for rendering the configuration.

The underlying issues is ofcourse that the table is missing.

Stack trace that calles append_sources is

````
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/active_record/index.rb:12:in `throw'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/active_record/index.rb:12:in `append_source'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/active_record/interpreter.rb:66:in `__source'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/active_record/interpreter.rb:22:in `indexes'
/Build_fllcasts/workspace/app/indices/course_index.rb:4:in `block in <top (required)>'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/core/interpreter.rb:5:in `translate!'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/core/index.rb:47:in `interpret_definition!'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/active_record/index.rb:46:in `sources'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration/consistent_ids.rb:33:in `collect'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration/consistent_ids.rb:33:in `sources'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration/consistent_ids.rb:21:in `attributes'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration/consistent_ids.rb:25:in `sphinx_internal_ids'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration/consistent_ids.rb:9:in `reconcile'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration.rb:174:in `normalise'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration.rb:93:in `block in preload_indices'
/usr/loca/rvm/rubies/ruby-2.4.6/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/configuration.rb:86:in `preload_indices'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/interfaces/sql.rb:7:in `initialize'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/rake_interface.rb:24:in `new'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/rake_interface.rb:24:in `sql'
/usr/loca/rvm/gems/ruby-2.4.6/gems/thinking-sphinx-4.3.2/lib/thinking_sphinx/tasks.rb:49:in `block (3 levels) in <top (required)>'
````

When there is a table in the db the append_sources is called. When there is no table the error is silently skipped and
a return for the method is called.