### PR TITLE
Explain what should be gitignored during setup

### DIFF
--- a/v4/installing_thinking_sphinx/ts4.md
+++ b/v4/installing_thinking_sphinx/ts4.md
@@ -51,6 +51,19 @@ gem 'thinking-sphinx', '~> 4.0.0',
   :ref    => 'cb45e1b1bf'
 {% endhighlight %}
 
+### Update .gitignore
+
+When you [start Sphinx](https://freelancing-gods.com/thinking-sphinx/v4/rake_tasks.html), a new folder called `/db/sphinx` will be created. The files contained are equivalent to your database's data files, and should be *not* be committed into version control.
+
+It's also recommended that you ignore the `config/ENV.sphinx.conf` files.
+
+Add the following lines to your `.gitignore` file to ignore these files:
+
+```
+/db/sphinx
+/config/*.sphinx.conf
+```
+
 ### Using Thinking Sphinx with Unicorn
 
 If you're using Unicorn as your web server, you'll want to ensure the connection pool is cleared after forking.


### PR DESCRIPTION
After getting set up with Thinking Sphinx, as I was about to commit my changes, I noticed the `db/sphinx` directory and files.

I had not come across an explanation of these files in the setup process, but they looked to me like data files in use by Sphinx.

I contacted @pat to ask if they should be `gitignored` and he recommended that they should be, along with the `config/ENV.sphinx.conf` files.

I've added some instructions to the Installing Thinking Sphinx step for the latest Rails version. This seemed intuitive to my use case, but if this is relevant to other platforms, maybe it should be in a more generic/visible place.

Thanks @pat

Luke