### PR TITLE
Explain how to reference the index with _core when Initializing Excerpter

### DIFF
--- a/v4/excerpts.md
+++ b/v4/excerpts.md
@@ -30,7 +30,7 @@ And then you can access excerpted text for any method on each search result:
 <% end %>
 {% endhighlight %}
 
-Instead of wrapping every single search result to add that helper method, you can instead create an `Excerpter` instance and call out to that:
+Instead of wrapping every single search result to add that helper method, you can instead create an `Excerpter` instance (the index is referenced by appending `_core` to its name), and call out to that:
 
 {% highlight ruby %}
 @articles  = Article.search params[:query]


### PR DESCRIPTION
This was a temporary gotcha for me when getting started with the `Excerpter`. I wasn't targeting my index correctly because I was using `item`, rather that `item_core`.

At the moment the explanation I've added is a bit arbitrary, it would be nice to explain why you add `_core` to the index name (maybe in the Indexing docs), but this small addition would have helped me I think.