### PR TITLE
DeltaCallbacks#before_save should obey Deltas.suspended?

### DIFF
--- a/lib/thinking_sphinx/active_record/callbacks/delta_callbacks.rb
+++ b/lib/thinking_sphinx/active_record/callbacks/delta_callbacks.rb
@@ -18,8 +18,7 @@ class ThinkingSphinx::ActiveRecord::Callbacks::DeltaCallbacks <
   end
 
   def before_save
-    return unless !ThinkingSphinx::Callbacks.suspended? && delta_indices? &&
-      new_or_changed?
+    return unless !suspended? && delta_indices? && new_or_changed?
 
     processors.each { |processor| processor.toggle instance }
   end


### PR DESCRIPTION
I'm guessing it's not intentional that after_commit uses `DeltaCallbacks#suspended?`, whereas before_save was using `ThinkingSphinx::Callbacks.suspended?` ?