### PR TITLE
Use instances for index filtering from callbacks.

### DIFF
--- a/lib/thinking_sphinx/active_record/callbacks/delete_callbacks.rb
+++ b/lib/thinking_sphinx/active_record/callbacks/delete_callbacks.rb
@@ -27,7 +27,7 @@ class ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks <
 
   def indices
     ThinkingSphinx::Configuration.instance.index_set_class.new(
-      :classes => [instance.class]
+      :instances => [instance], :classes => [instance.class]
     ).to_a
   end
 end

--- a/lib/thinking_sphinx/active_record/callbacks/delta_callbacks.rb
+++ b/lib/thinking_sphinx/active_record/callbacks/delta_callbacks.rb
@@ -43,8 +43,9 @@ class ThinkingSphinx::ActiveRecord::Callbacks::DeltaCallbacks <
   end
 
   def indices
-    @indices ||= config.index_set_class.new(:classes => [instance.class]).
-      select { |index| index.type == "plain" }
+    @indices ||= config.index_set_class.new(
+      :instances => [instance], :classes => [instance.class]
+    ).select { |index| index.type == "plain" }
   end
 
   def new_or_changed?

--- a/lib/thinking_sphinx/index_set.rb
+++ b/lib/thinking_sphinx/index_set.rb
@@ -34,11 +34,11 @@ class ThinkingSphinx::IndexSet
   end
 
   def classes
-    options[:classes] || []
+    options[:classes] || instances.collect(&:class)
   end
 
   def classes_specified?
-    classes.any? || references_specified?
+    instances.any? || classes.any? || references_specified?
   end
 
   def classes_and_ancestors
@@ -66,6 +66,10 @@ class ThinkingSphinx::IndexSet
 
   def indices_for_references
     all_indices.select { |index| references.include? index.reference }
+  end
+
+  def instances
+    options[:instances] || []
   end
 
   def mti_classes

--- a/spec/thinking_sphinx/index_set_spec.rb
+++ b/spec/thinking_sphinx/index_set_spec.rb
@@ -68,6 +68,18 @@ describe ThinkingSphinx::IndexSet do
       expect(set.to_a).to eq([article_index])
     end
 
+    it "uses indices for the given instance's class" do
+      configuration.indices.replace [
+        article_index, opinion_article_index, page_index
+      ]
+
+      instance_class = class_double('Article', :column_names => [])
+
+      options[:instances] = [double(:instance, :class => instance_class)]
+
+      expect(set.to_a).to eq([article_index])
+    end
+
     it "requests indices for any STI superclasses" do
       configuration.indices.replace [
         article_index, opinion_article_index, page_index

--- a/spec/thinking_sphinx/index_set_spec.rb
+++ b/spec/thinking_sphinx/index_set_spec.rb
@@ -30,6 +30,16 @@ describe ThinkingSphinx::IndexSet do
   end
 
   describe '#to_a' do
+    let(:article_index) do
+      double(:reference => :article, :distributed? => false)
+    end
+    let(:opinion_article_index) do
+      double(:reference => :opinion_article, :distributed? => false)
+    end
+    let(:page_index) do
+      double(:reference => :page, :distributed? => false)
+    end
+
     it "ensures the indices are loaded" do
       expect(configuration).to receive(:preload_indices)
 
@@ -50,21 +60,17 @@ describe ThinkingSphinx::IndexSet do
 
     it "uses indices for the given classes" do
       configuration.indices.replace [
-        double(:reference => :article,         :distributed? => false),
-        double(:reference => :opinion_article, :distributed? => false),
-        double(:reference => :page,            :distributed? => false)
+        article_index, opinion_article_index, page_index
       ]
 
       options[:classes] = [class_double('Article', :column_names => [])]
 
-      expect(set.to_a.length).to eq(1)
+      expect(set.to_a).to eq([article_index])
     end
 
     it "requests indices for any STI superclasses" do
       configuration.indices.replace [
-        double(:reference => :article,         :distributed? => false),
-        double(:reference => :opinion_article, :distributed? => false),
-        double(:reference => :page,            :distributed? => false)
+        article_index, opinion_article_index, page_index
       ]
 
       article = class_double('Article', :column_names => [:type])
@@ -73,14 +79,12 @@ describe ThinkingSphinx::IndexSet do
 
       options[:classes] = [opinion]
 
-      expect(set.to_a.length).to eq(2)
+      expect(set.to_a).to eq([article_index, opinion_article_index])
     end
 
     it "does not use MTI superclasses" do
       configuration.indices.replace [
-        double(:reference => :article,         :distributed? => false),
-        double(:reference => :opinion_article, :distributed? => false),
-        double(:reference => :page,            :distributed? => false)
+        article_index, opinion_article_index, page_index
       ]
 
       article = class_double('Article', :column_names => [])
@@ -88,7 +92,7 @@ describe ThinkingSphinx::IndexSet do
 
       options[:classes] = [opinion]
 
-      expect(set.to_a.length).to eq(1)
+      expect(set.to_a).to eq([opinion_article_index])
     end
 
     it "uses named indices if names are provided" do


### PR DESCRIPTION
Prompted by discussions in #1166, this PR changes the IndexSet class to accept `:instances` alongside the `:classes` option, which could allow custom subclasses of IndexSet to filter returned indices to a subset as determined by the provided instances.

In particular, if you're sharding your indices, you can return just the specific shard of indices for the instance, rather than _all_ shards:

```ruby
class IndexSet < ThinkingSphinx::IndexSet
  private

  def indices
    return super if instances.empty?

    super.select do |index|
      # shard_id or equivalent logic needs to be implemented.
      # this would return all core and delta indices for the instance's model,
      # filtered by the shard id for the instance.
      instances.any? { |instance| index.name[/_#{instance.shard_id}_$/] }
    end
  end
end

# This line would go in an initialiser:
ThinkingSphinx::Configuration.instance.index_set_class = IndexSet
```

While it's not necessary moving forward, I'm still passing through the `:classes` option for anyone who's got a custom IndexSet class that depends on that.