### PR TITLE
Switch to explicitly-added callbacks.

### DIFF
--- a/lib/thinking_sphinx/active_record/base.rb
+++ b/lib/thinking_sphinx/active_record/base.rb
@@ -4,11 +4,6 @@ module ThinkingSphinx::ActiveRecord::Base
   extend ActiveSupport::Concern
 
   included do
-    after_destroy ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks
-    before_save   ThinkingSphinx::ActiveRecord::Callbacks::DeltaCallbacks
-    after_update  ThinkingSphinx::ActiveRecord::Callbacks::UpdateCallbacks
-    after_commit  ThinkingSphinx::ActiveRecord::Callbacks::DeltaCallbacks
-
     if ActiveRecord::VERSION::STRING.to_i >= 5
       [
         ::ActiveRecord::Reflection::HasManyReflection,

--- a/lib/thinking_sphinx/callbacks.rb
+++ b/lib/thinking_sphinx/callbacks.rb
@@ -3,6 +3,13 @@
 class ThinkingSphinx::Callbacks
   attr_reader :instance
 
+  def self.append(model, reference = nil, options, &block)
+    reference ||= ThinkingSphinx::Configuration.instance.index_set_class.
+      reference_name(model)
+
+    ThinkingSphinx::Callbacks::Appender.call(model, reference, options, &block)
+  end
+
   def self.callbacks(*methods)
     mod = Module.new
     methods.each do |method|
@@ -33,3 +40,5 @@ class ThinkingSphinx::Callbacks
     @instance = instance
   end
 end
+
+require "thinking_sphinx/callbacks/appender"

--- a/lib/thinking_sphinx/callbacks/appender.rb
+++ b/lib/thinking_sphinx/callbacks/appender.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ThinkingSphinx::Callbacks::Appender
+  def self.call(model, reference, options, &block)
+    new(model, reference, options, &block).call
+  end
+
+  def initialize(model, reference, options, &block)
+    @model = model
+    @reference = reference
+    @options = options
+    @block = block
+  end
+
+  def call
+    model.after_destroy ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks
+
+    if behaviours.include?(:deltas)
+      model.before_save  ThinkingSphinx::ActiveRecord::Callbacks::DeltaCallbacks
+      model.after_commit ThinkingSphinx::ActiveRecord::Callbacks::DeltaCallbacks
+    end
+
+    if behaviours.include?(:real_time)
+      model.after_save ThinkingSphinx::RealTime.callback_for(
+        reference, path, &block
+      )
+    end
+
+    if behaviours.include?(:updates)
+      model.after_update(
+        ThinkingSphinx::ActiveRecord::Callbacks::UpdateCallbacks
+      )
+    end
+  end
+
+  private
+
+  attr_reader :model, :reference, :options, :block
+
+  def behaviours
+    options[:behaviours] || []
+  end
+
+  def path
+    options[:path] || []
+  end
+end

--- a/spec/internal/app/models/admin/person.rb
+++ b/spec/internal/app/models/admin/person.rb
@@ -3,5 +3,7 @@
 class Admin::Person < ActiveRecord::Base
   self.table_name = 'admin_people'
 
-  after_save ThinkingSphinx::RealTime.callback_for('admin/person')
+  ThinkingSphinx::Callbacks.append(
+    self, 'admin/person', :behaviours => [:sql, :real_time]
+  )
 end

--- a/spec/internal/app/models/album.rb
+++ b/spec/internal/app/models/album.rb
@@ -6,7 +6,9 @@ class Album < ActiveRecord::Base
   before_validation :set_id, :on => :create
   before_validation :set_integer_id, :on => :create
 
-  after_save ThinkingSphinx::RealTime.callback_for(:album)
+  ThinkingSphinx::Callbacks.append(
+    self, :behaviours => [:sql, :real_time, :deltas]
+  )
 
   validates :id,         :presence => true, :uniqueness => true
   validates :integer_id, :presence => true, :uniqueness => true

--- a/spec/internal/app/models/animal.rb
+++ b/spec/internal/app/models/animal.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Animal < ActiveRecord::Base
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql])
 end

--- a/spec/internal/app/models/article.rb
+++ b/spec/internal/app/models/article.rb
@@ -4,4 +4,6 @@ class Article < ActiveRecord::Base
   belongs_to :user
   has_many :taggings
   has_many :tags, :through => :taggings
+
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql, :updates])
 end

--- a/spec/internal/app/models/bird.rb
+++ b/spec/internal/app/models/bird.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Bird < Animal
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql])
 end

--- a/spec/internal/app/models/book.rb
+++ b/spec/internal/app/models/book.rb
@@ -5,6 +5,8 @@ class Book < ActiveRecord::Base
 
   has_and_belongs_to_many :genres
 
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql, :deltas])
+
   sphinx_scope(:by_query) { |query| query }
   sphinx_scope(:by_year) do |year|
     {:with => {:year => year}}

--- a/spec/internal/app/models/car.rb
+++ b/spec/internal/app/models/car.rb
@@ -3,5 +3,5 @@
 class Car < ActiveRecord::Base
   belongs_to :manufacturer
 
-  after_save ThinkingSphinx::RealTime.callback_for(:car)
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:real_time])
 end

--- a/spec/internal/app/models/city.rb
+++ b/spec/internal/app/models/city.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class City < ActiveRecord::Base
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql])
+
   scope :ordered, lambda { order(:name) }
 end

--- a/spec/internal/app/models/product.rb
+++ b/spec/internal/app/models/product.rb
@@ -4,5 +4,5 @@ class Product < ActiveRecord::Base
   has_many :categorisations
   has_many :categories, :through => :categorisations
 
-  after_save ThinkingSphinx::RealTime.callback_for(:product)
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:real_time])
 end

--- a/spec/internal/app/models/tee.rb
+++ b/spec/internal/app/models/tee.rb
@@ -2,4 +2,6 @@
 
 class Tee < ActiveRecord::Base
   belongs_to :colour
+
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql])
 end

--- a/spec/internal/app/models/user.rb
+++ b/spec/internal/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ActiveRecord::Base
   has_many :articles
 
+  ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql])
+
   default_scope { order(:id) }
   scope :recent, lambda { where('created_at > ?', 1.week.ago) }
 end


### PR DESCRIPTION
As discussed in #1173 and initially prompted by discussions in #1158, this commit removes the automatic insertion of callbacks into every single ActiveRecord model, and instead expects them to be explicitly added to the models that are indexed. The syntax is as follows:

```ruby
ThinkingSphinx::Callbacks.append(model, reference, options, &block)
```

Given this code will almost always be invoked from within an ActiveRecord model, the `model` argument will be `self`.

The `reference` is optional, but should match the first argument of the index in question. e.g. it’ll likely be the model name, lowercase and underscored, as a symbol. If the model is namespaced, though, this should be a string, with slashes to indicate the namespacing (like how a namespaced index is defined).

The options are `behaviour` and `path`. Behaviour is an array of symbols, which include the following:
* `:sql` for SQL-backed indices.
* `:real_time` for real-time indices.
* `:deltas` if the SQL-backed indices have deltas enabled.
* `:updates` if `attribute_updates` is configured to true (which is probably not the case for many people). This is only for SQL-backed indices.

Both the path option and the block argument are the same as what would have been passed into `ThinkingSphinx::RealTime.callback_for`, and have no impact for SQL-backed callbacks. This new approach replaces the need for `ThinkingSphinx::RealTime.callback_for` (but it continues to work for now).