### PR TITLE
Use CircleCI instead of Travis, and confirm Rails 6.1 support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,150 @@
+version: 2.1
+
+orbs:
+  ruby: circleci/ruby@1.0
+
+workflows:
+  test:
+    jobs:
+      - test:
+          name: "Sphinx 2.2.11 with MySQL"
+          database: mysql2
+          sphinx_version: 2.2.11
+          sphinx_engine: sphinx
+          debian: jessie
+          ruby: '2.4.6'
+      - test:
+          name: "Sphinx 2.2.11 with PostgreSQL"
+          database: postgresql
+          sphinx_version: 2.2.11
+          sphinx_engine: sphinx
+          debian: jessie
+          ruby: '2.4.6'
+      - test:
+          name: "Sphinx 3.3.1 with MySQL"
+          database: mysql2
+          sphinx_version: 3.3.1
+          sphinx_engine: sphinx
+          debian: buster
+          matrix:
+            parameters:
+              ruby: [ '2.4.9', '2.5.8', '2.6.6', '2.7.2' ]
+      # - test:
+      #     database: postgresql
+      #     sphinx_version: 3.3.1
+      #     sphinx_engine: sphinx
+      #     matrix:
+      #       parameters:
+      #         ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+      - test:
+          name: "Manticore 2.8.2 with MySQL"
+          database: mysql2
+          sphinx_version: 2.8.2
+          sphinx_engine: manticore
+          debian: stretch
+          matrix:
+            parameters:
+              ruby: [ '2.4.9', '2.5.8', '2.6.6' ]
+      - test:
+          name: "Manticore 2.8.2 with PostgreSQL"
+          database: postgresql
+          sphinx_version: 2.8.2
+          sphinx_engine: manticore
+          debian: stretch
+          matrix:
+            parameters:
+              ruby: [ '2.4.9', '2.5.8', '2.6.6' ]
+      - test:
+          name: "Manticore 3.5.4 with MySQL"
+          database: mysql2
+          sphinx_version: 3.5.4
+          sphinx_engine: manticore
+          debian: buster
+          matrix:
+            parameters:
+              ruby: [ '2.4.9', '2.5.8', '2.6.6', '2.7.2' ]
+      - test:
+          name: "Manticore 3.5.4 with PostgreSQL"
+          database: postgresql
+          sphinx_version: 3.5.4
+          sphinx_engine: manticore
+          debian: buster
+          matrix:
+            parameters:
+              ruby: [ '2.4.9', '2.5.8', '2.6.6', '2.7.2' ]
+
+jobs:
+  test:
+    parameters:
+      ruby:
+        type: string
+      database:
+        type: string
+      sphinx_version:
+        type: string
+      sphinx_engine:
+        type: string
+      debian:
+        type: string
+
+    docker:
+      - image: circleci/ruby:<< parameters.ruby >>-<< parameters.debian >>
+
+      - image: circleci/postgres:10
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: thinking_sphinx
+          POSTGRES_DB: thinking_sphinx
+
+      - image: circleci/mysql:5.7
+        environment:
+          MYSQL_ROOT_PASSWORD: thinking_sphinx
+          MYSQL_DATABASE: thinking_sphinx
+
+    working_directory: ~/app
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-<< parameters.ruby >>
+
+      - run:
+          name: install bundler
+          command: |
+            if [ "<< parameters.ruby >>" == "2.7.2" ]; then
+              export BUNDLER_VERSION=2.1.4
+            else
+              export BUNDLER_VERSION=1.17.3
+            fi
+            export BUNDLE_PATH=vendor/bundle
+            gem install bundler:$BUNDLER_VERSION
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle update
+
+      - run:
+          name: set up appraisal
+          command: bundle exec appraisal update
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-<< parameters.ruby >>
+
+      - run:
+          name: set up sphinx
+          command: "./bin/loadsphinx << parameters.sphinx_version >> << parameters.sphinx_engine >>"
+
+      - run:
+          name: tests
+          environment:
+            CI: "true"
+            DATABASE: << parameters.database >>
+            SPHINX_VERSION: << parameters.sphinx_version >>
+            SPHINX_ENGINE: << parameters.sphinx_engine >>
+          command: bundle exec appraisal rspec

--- a/Appraisals
+++ b/Appraisals
@@ -33,3 +33,9 @@ appraise 'rails_6_0' do
   gem 'mysql2', '~> 0.5.0', :platform => :ruby
   gem 'pg',     '~> 1.0',   :platform => :ruby
 end if RUBY_PLATFORM != 'java' && RUBY_VERSION.to_f >= 2.5
+
+appraise 'rails_6_1' do
+  gem 'rails',  '~> 6.1.0'
+  gem 'mysql2', '~> 0.5.0', :platform => :ruby
+  gem 'pg',     '~> 1.0',   :platform => :ruby
+end if RUBY_PLATFORM != 'java' && RUBY_VERSION.to_f >= 2.5

--- a/bin/loadsphinx
+++ b/bin/loadsphinx
@@ -14,7 +14,7 @@ load_sphinx () {
       format="deb"
       distro="trusty";;
     2.2.11)
-      url="http://sphinxsearch.com/files/sphinxsearch_2.2.11-release-1~xenial_amd64.deb"
+      url="http://sphinxsearch.com/files/sphinxsearch_2.2.11-release-1~jessie_amd64.deb"
       format="deb";;
     3.0.3)
       url="http://sphinxsearch.com/files/sphinx-3.0.3-facc3fb-linux-amd64.tar.gz"
@@ -40,7 +40,9 @@ load_sphinx () {
 
   if [ "$format" == "deb" ]; then
     curl --location $url -o sphinx.deb
-    sudo apt-get install ./sphinx.deb
+    sudo apt-get install libodbc1
+    sudo dpkg -i ./sphinx.deb
+    sudo apt-get install -f
   else
     curl $url -o sphinx.tar.gz
     tar -zxvf sphinx.tar.gz
@@ -57,18 +59,19 @@ load_manticore () {
     2.7.5)
       url="https://github.com/manticoresoftware/manticoresearch/releases/download/2.7.5/manticore_2.7.5-181204-4a31c54-release-stemmer.xenial_amd64-bin.deb";;
     2.8.2)
-      url="https://github.com/manticoresoftware/manticoresearch/releases/download/2.8.2/manticore_2.8.2-190402-4e81114-release-stemmer.xenial_amd64-bin.deb";;
+      url="https://github.com/manticoresoftware/manticoresearch/releases/download/2.8.2/manticore_2.8.2-190402-4e81114d-release-stemmer.stretch_amd64-bin.deb";;
     3.4.2)
       url="https://github.com/manticoresoftware/manticoresearch/releases/download/3.4.2/manticore_3.4.2-200410-6903305-release.xenial_amd64-bin.deb";;
-    3.5.0)
-      url="https://repo.manticoresearch.com/repository/manticoresearch_xenial/pool/m/manticore/manticore_3.5.0-200722-1d34c49_amd64.deb";;
+    3.5.4)
+      url="https://repo.manticoresearch.com/repository/manticoresearch_buster/pool/m/manticore/manticore_3.5.4-201211-13f8d08d_amd64.deb";;
     *)
       echo "No Manticore version $version available"
       exit 1;;
   esac
 
   curl --location $url -o manticore.deb
-  sudo apt-get install ./manticore.deb
+  sudo dpkg -i ./manticore.deb
+  sudo apt-get install -f
 }
 
 if [ "$engine" == "sphinx" ]; then

--- a/spec/acceptance/geosearching_spec.rb
+++ b/spec/acceptance/geosearching_spec.rb
@@ -38,7 +38,17 @@ describe 'Searching by latitude and longitude', :live => true do
       expected = {:mysql => 250326.906250, :postgresql => 250331.234375}
     end
 
-    if ActiveRecord::Base.configurations['test']['adapter'][/postgres/]
+    adapter = nil
+
+    if ActiveRecord::VERSION::STRING.to_f > 6.0
+      adapter = ActiveRecord::Base.configurations.configs_for.first.adapter
+    elsif ActiveRecord::VERSION::STRING.to_f > 5.2
+      adapter = ActiveRecord::Base.configurations.configs_for.first.config["adapter"]
+    else
+      adapter = ActiveRecord::Base.configurations['test']['adapter']
+    end
+
+    if adapter[/postgres/]
       expect(cities.first.geodist).to be_within(0.01).of(expected[:postgresql])
     else # mysql
       expect(cities.first.geodist).to be_within(0.01).of(expected[:mysql])

--- a/spec/acceptance/support/sphinx_helpers.rb
+++ b/spec/acceptance/support/sphinx_helpers.rb
@@ -6,22 +6,22 @@ module SphinxHelpers
   end
 
   def index(*indices)
-    sleep 0.5 if ENV['TRAVIS']
+    sleep 0.5 if ENV['CI']
 
     yield if block_given?
 
     sphinx.index *indices
     sleep 0.25
-    sleep 0.5 if ENV['TRAVIS']
+    sleep 0.5 if ENV['CI']
   end
 
   def merge
-    sleep 0.5 if ENV['TRAVIS']
+    sleep 0.5 if ENV['CI']
     sleep 0.5
 
     sphinx.merge
     sleep 1.5
-    sleep 0.5 if ENV['TRAVIS']
+    sleep 0.5 if ENV['CI']
   end
 end
 

--- a/spec/internal/config/database.yml
+++ b/spec/internal/config/database.yml
@@ -1,6 +1,11 @@
 test:
   adapter:      <%= ENV['DATABASE'] || 'mysql2' %>
   database:     thinking_sphinx
-  username:     <%= ENV['DATABASE'] == 'postgresql' ? ENV['USER'] : 'root' %>
+  username:     <%= ENV['DATABASE'] == 'postgresql' ? 'postgres' : 'root' %>
+<% if ENV["CI"] %>
+  password:     thinking_sphinx
+  host:         127.0.0.1
+  port:         <%= ENV['DATABASE'] == 'postgresql' ? 5432 : 3306 %>
+<% end %>
   min_messages: warning
   encoding:     utf8


### PR DESCRIPTION
Travis sadly no longer supports open-source projects for free. GitHub Actions seemed promising, but there is no ability to retry single/failed jobs. CircleCI works well enough with a bit of wrangling (using Debian rather than Ubuntu Sphinx/Manticore releases).