### PR TITLE
Clean up orphaned real-time records after reindexing.

### DIFF
--- a/lib/thinking_sphinx/real_time/index/template.rb
+++ b/lib/thinking_sphinx/real_time/index/template.rb
@@ -13,7 +13,10 @@ class ThinkingSphinx::RealTime::Index::Template
     add_attribute primary_key,  :sphinx_internal_id,    :bigint
     add_attribute class_column, :sphinx_internal_class, :string, :facet => true
     add_attribute 0,            :sphinx_deleted,        :integer
-    add_attribute 0,            :sphinx_updated_at,     :timestamp if tidying?
+
+    if tidying?
+      add_attribute -> (_) { Time.current.to_i }, :sphinx_updated_at, :timestamp
+    end
   end
 
   private

--- a/lib/thinking_sphinx/real_time/index/template.rb
+++ b/lib/thinking_sphinx/real_time/index/template.rb
@@ -13,6 +13,7 @@ class ThinkingSphinx::RealTime::Index::Template
     add_attribute primary_key,  :sphinx_internal_id,    :bigint
     add_attribute class_column, :sphinx_internal_class, :string, :facet => true
     add_attribute 0,            :sphinx_deleted,        :integer
+    add_attribute 0,            :sphinx_updated_at,     :timestamp if tidying?
   end
 
   private
@@ -34,7 +35,15 @@ class ThinkingSphinx::RealTime::Index::Template
     [:class, :name]
   end
 
+  def config
+    ThinkingSphinx::Configuration.instance
+  end
+
   def primary_key
     index.primary_key.to_sym
+  end
+
+  def tidying?
+    config.settings["real_time_tidy"]
   end
 end

--- a/lib/thinking_sphinx/real_time/populator.rb
+++ b/lib/thinking_sphinx/real_time/populator.rb
@@ -7,6 +7,7 @@ class ThinkingSphinx::RealTime::Populator
 
   def initialize(index)
     @index = index
+    @started_at = Time.current
   end
 
   def populate
@@ -17,12 +18,14 @@ class ThinkingSphinx::RealTime::Populator
       instrument 'populated', :instances => instances
     end
 
+    transcriber.clear_before(started_at) if configuration.settings["real_time_tidy"]
+
     instrument 'finish_populating'
   end
 
   private
 
-  attr_reader :index
+  attr_reader :index, :started_at
 
   delegate :controller, :batch_size, :to => :configuration
   delegate :scope,                   :to => :index

--- a/lib/thinking_sphinx/real_time/transcriber.rb
+++ b/lib/thinking_sphinx/real_time/transcriber.rb
@@ -5,6 +5,12 @@ class ThinkingSphinx::RealTime::Transcriber
     @index = index
   end
 
+  def clear_before(time)
+    execute <<~SQL.strip
+      DELETE FROM #{@index.name} WHERE sphinx_updated_at < #{time.to_i}
+    SQL
+  end
+
   def copy(*instances)
     items = instances.select { |instance|
       instance.persisted? && copy?(instance)

--- a/lib/thinking_sphinx/real_time/translator.rb
+++ b/lib/thinking_sphinx/real_time/translator.rb
@@ -10,6 +10,7 @@ class ThinkingSphinx::RealTime::Translator
   end
 
   def call
+    return name.call(object) if name.is_a?(Proc)
     return name   unless name.is_a?(Symbol)
     return result unless result.is_a?(String)
 

--- a/lib/thinking_sphinx/settings.rb
+++ b/lib/thinking_sphinx/settings.rb
@@ -19,7 +19,8 @@ class ThinkingSphinx::Settings
     "binlog_path"              => "tmp/binlog/ENVIRONMENT",
     "workers"                  => "threads",
     "mysql_encoding"           => "utf8",
-    "maximum_statement_length" => (2 ** 23) - 5
+    "maximum_statement_length" => (2 ** 23) - 5,
+    "real_time_tidy"           => false
   }.freeze
 
   def self.call(configuration)

--- a/spec/thinking_sphinx/real_time/index_spec.rb
+++ b/spec/thinking_sphinx/real_time/index_spec.rb
@@ -5,7 +5,9 @@ require 'spec_helper'
 describe ThinkingSphinx::RealTime::Index do
   let(:index)        { ThinkingSphinx::RealTime::Index.new :user }
   let(:config)       { double('config', :settings => {},
-    :indices_location => 'location', :next_offset => 8) }
+    :indices_location => 'location', :next_offset => 8,
+    :index_set_class => index_set_class) }
+  let(:index_set_class) { double(:index_set_class, :reference_name => :user) }
 
   before :each do
     allow(ThinkingSphinx::Configuration).to receive_messages :instance => config
@@ -60,6 +62,16 @@ describe ThinkingSphinx::RealTime::Index do
 
     it "has the internal deleted attribute by default" do
       expect(index.attributes.collect(&:name)).to include('sphinx_deleted')
+    end
+
+    it "does not have an internal updated_at attribute by default" do
+      expect(index.attributes.collect(&:name)).to_not include('sphinx_updated_at')
+    end
+
+    it "has an internal updated_at attribute if real_time_tidy is true" do
+      config.settings["real_time_tidy"] = true
+
+      expect(index.attributes.collect(&:name)).to include('sphinx_updated_at')
     end
   end
 


### PR DESCRIPTION
This PR adds a new internal attribute - `sphinx_updated_at` - to real-time indices, and sets that with the current timestamp whenever that record is inserted or updated. And then, when a reindex happens, any record that has not changed since the reindexing began is removed - as it's not in the known dataset. Likely, it was deleted but the callbacks failed for some reason.

The advantage of this is that running `ts:index` will remove any records that are no longer indexed - thus keeping index sizes to what they should be, avoiding any bloat that may crop up from situations where records haven't been removed (bulk deletions, for example) - and this is done without the need for deleting _all_ records to begin with (the behaviour of `ts:rebuild`).

This is currently only enabled with `real_time_tidy` is set to true for the appropriate environment in `config/thinking_sphinx.yml`. I see it defaulting to true in the near future, but that might not be until v6.0.