### PR TITLE
Don't load ActiveRecord during rails initialization

### DIFF
--- a/lib/thinking_sphinx.rb
+++ b/lib/thinking_sphinx.rb
@@ -96,12 +96,15 @@ require 'thinking_sphinx/test'
 require 'thinking_sphinx/utf8'
 require 'thinking_sphinx/wildcard'
 # Extended
-require 'thinking_sphinx/active_record'
 require 'thinking_sphinx/deltas'
 require 'thinking_sphinx/distributed'
 require 'thinking_sphinx/logger'
 require 'thinking_sphinx/real_time'
 
-require 'thinking_sphinx/railtie' if defined?(Rails::Railtie)
+if defined?(Rails::Railtie)
+  require 'thinking_sphinx/railtie'
+else
+  require 'thinking_sphinx/active_record'
+end
 
 ThinkingSphinx.before_index_hooks << ThinkingSphinx::Hooks::GuardPresence

--- a/lib/thinking_sphinx/railtie.rb
+++ b/lib/thinking_sphinx/railtie.rb
@@ -7,6 +7,7 @@ class ThinkingSphinx::Railtie < Rails::Railtie
 
   initializer 'thinking_sphinx.initialisation' do
     ActiveSupport.on_load(:active_record) do
+      require 'thinking_sphinx/active_record'
       ActiveRecord::Base.include ThinkingSphinx::ActiveRecord::Base
     end
 


### PR DESCRIPTION
If ThinkingSphinx requires ActiveRecord on load, then setting configuration in applications' initializers with have no effect (eg
`Rails.application.config.active_record.has_many_inversing`).

Instead, ActiveRecord should be deferred to the end of initialization using the Railtie. WDYT to something like this?