### PR TITLE
Use after_commit callbacks for real-time changes.

### DIFF
--- a/lib/thinking_sphinx/active_record/callbacks/delete_callbacks.rb
+++ b/lib/thinking_sphinx/active_record/callbacks/delete_callbacks.rb
@@ -3,7 +3,11 @@
 class ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks <
   ThinkingSphinx::Callbacks
 
-  callbacks :after_destroy, :after_rollback
+  callbacks :after_commit, :after_destroy, :after_rollback
+
+  def after_commit
+    delete_from_sphinx
+  end
 
   def after_destroy
     delete_from_sphinx

--- a/lib/thinking_sphinx/callbacks/appender.rb
+++ b/lib/thinking_sphinx/callbacks/appender.rb
@@ -24,7 +24,10 @@ class ThinkingSphinx::Callbacks::Appender
   attr_reader :model, :reference, :options, :block
 
   def add_core_callbacks
-    model.after_destroy ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks
+    model.after_commit(
+      ThinkingSphinx::ActiveRecord::Callbacks::DeleteCallbacks,
+      on: :destroy
+    )
   end
 
   def add_delta_callbacks
@@ -40,8 +43,9 @@ class ThinkingSphinx::Callbacks::Appender
   end
 
   def add_real_time_callbacks
-    model.after_save ThinkingSphinx::RealTime.callback_for(
-      reference, path, &block
+    model.after_commit(
+      ThinkingSphinx::RealTime.callback_for(reference, path, &block),
+      on: [:create, :update]
     )
   end
 

--- a/spec/acceptance/sql_deltas_spec.rb
+++ b/spec/acceptance/sql_deltas_spec.rb
@@ -16,7 +16,7 @@ describe 'SQL delta indexing', :live => true do
     )
     sleep 0.25
 
-    expect(Book.search('Terry Pratchett').to_a).to eq([guards, men])
+    expect(Book.search('Terry Pratchett').to_a).to match_array([guards, men])
   end
 
   it "automatically indexes updated records" do

--- a/spec/thinking_sphinx/active_record/index_spec.rb
+++ b/spec/thinking_sphinx/active_record/index_spec.rb
@@ -5,7 +5,9 @@ require 'spec_helper'
 describe ThinkingSphinx::ActiveRecord::Index do
   let(:index)        { ThinkingSphinx::ActiveRecord::Index.new :user }
   let(:config)       { double('config', :settings => {},
-    :indices_location => 'location', :next_offset => 8) }
+    :indices_location => 'location', :next_offset => 8,
+    :index_set_class => index_set_class) }
+  let(:index_set_class) { double :reference_name => :user }
 
   before :each do
     allow(ThinkingSphinx::Configuration).to receive_messages :instance => config


### PR DESCRIPTION
This also applies to deletions generally (no matter what type of indices are in play).

This was prompted by feedback from @krauselukas in #1203. It certainly makes more sense to wait until the database changes are fully committed before we update Sphinx, so I feel like this switch is a smart one.