### PR TITLE
support rails 7

### DIFF
--- a/lib/thinking_sphinx/railtie.rb
+++ b/lib/thinking_sphinx/railtie.rb
@@ -14,8 +14,9 @@ class ThinkingSphinx::Railtie < Rails::Railtie
       require 'thinking_sphinx/active_record'
     end
 
-    if ActiveSupport::VERSION::MAJOR > 5 &&
-      Rails.application.config.autoloader == :zeitwerk
+    if ActiveSupport::VERSION::MAJOR == 7 ||
+       (ActiveSupport::VERSION::MAJOR > 5 &&
+        Rails.application.config.autoloader == :zeitwerk)
       ActiveSupport::Dependencies.autoload_paths.delete(
         Rails.root.join("app", "indices").to_s
       )


### PR DESCRIPTION
Rails 7 uses zeitwerk exclusively: https://weblog.rubyonrails.org/2021/9/15/Rails-7-0-alpha-1-released. So, checking for the autoloader breaks as it is no longer defined in the config.