### PR TITLE
Include instance_exec in ThinkingSphinx::Search::CORE_METHODS

### DIFF
--- a/lib/thinking_sphinx/search.rb
+++ b/lib/thinking_sphinx/search.rb
@@ -2,7 +2,7 @@
 
 class ThinkingSphinx::Search < Array
   CORE_METHODS = %w( == class class_eval extend frozen? id instance_eval
-    instance_of? instance_values instance_variable_defined?
+    instance_exec instance_of? instance_values instance_variable_defined?
     instance_variable_get instance_variable_set instance_variables is_a?
     kind_of? member? method methods nil? object_id respond_to?
     respond_to_missing? send should should_not type )


### PR DESCRIPTION
I ran into this when trying to instrument `ThinkingSphinx::Search#populate` with NewRelic 8, where `add_method_tracer :populate` relies on `instance_exec`. This would fail because ThinkingSphinx::Search undefs all instance methods not included in a safe-list.