### PR TITLE
fixes a weird bug: search.total_pages is always 1

### DIFF
--- a/lib/thinking_sphinx/masks/pagination_mask.rb
+++ b/lib/thinking_sphinx/masks/pagination_mask.rb
@@ -51,7 +51,7 @@ class ThinkingSphinx::Masks::PaginationMask
   def total_pages
     return 0 if search.meta['total'].nil?
 
-    @total_pages ||= (search.meta['total'].to_i / search.per_page.to_f).ceil
+    @total_pages ||= (total_entries / search.per_page.to_f).ceil
   end
 
   alias_method :page_count, :total_pages


### PR DESCRIPTION
under manticore 4.2.0 the pagination doesn't work because the search function returns total_pages = 1 every time

```
2.7.4 :001 > @books = Book.search('test', per_page: 5)
2.7.4 :002 > @books.total_count
 => 220 
2.7.4 :003 > @books.total_pages
 => 1 
```

search.meta => {"total"=>"5", "total_found"=>"220", "time"=>"0.000", "keyword[0]"=>"test", "docs[0]"=>"220", "hits[0]"=>"302"}

i think my fix solves this problem and doesn't generate another :)