### PR TITLE
Use YAML.unsafe_load to load configuration file

### DIFF
--- a/lib/thinking_sphinx/settings.rb
+++ b/lib/thinking_sphinx/settings.rb
@@ -100,7 +100,7 @@ class ThinkingSphinx::Settings
     input = File.read file
     input = ERB.new(input).result if defined?(ERB)
 
-    contents = YAML.load input
+    contents = YAML.unsafe_load input
     contents && contents[framework.environment] || {}
   end
 


### PR DESCRIPTION
Ruby 3.1 comes with Psych 4 which has some breaking changes to `YAML.load` [See this ruby issue](https://bugs.ruby-lang.org/issues/17866). 

I had been using a `config/thinking_sphinx.yml` file with aliases, which failed to load after I upgraded  a rails app to ruby 3.1. Here's an example configuration:
``` yaml
defaults: &defaults
  min_word_len: 2
  charset_table: "0..9, A..Z->a..z, _, a..z, \
  U+410..U+42F->U+430..U+44F, U+430..U+44F"

test:
  <<: *defaults
  mysql41: 9313

development:
  <<: *defaults

production:
  <<: *defaults
  address: 10.0.0.1
```
Such a configuration works with ruby versions prior to 3.1. 