### PR TITLE
Ruby 3 - File.exists? is deprecated; use File.exist? instead

### DIFF
--- a/lib/thinking_sphinx/guard/file.rb
+++ b/lib/thinking_sphinx/guard/file.rb
@@ -12,7 +12,7 @@ class ThinkingSphinx::Guard::File
   end
 
   def locked?
-    File.exists? path
+    File.exist? path
   end
 
   def path


### PR DESCRIPTION
Replaced deprecated File.exist?