### PR TITLE
decide per index to reconcile class name field

### DIFF
--- a/spec/thinking_sphinx/configuration/minimum_fields_spec.rb
+++ b/spec/thinking_sphinx/configuration/minimum_fields_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe ThinkingSphinx::Configuration::MinimumFields do
     expect(index_b.fields).to eq([field_b2])
   end
 
-  it 'keeps the class name fields when one index model has a type column' do
+  it 'removes the class name fields only for the indices without type column' do
     allow(model_a).to receive(:column_names).and_return(['id', 'name', 'type'])
     allow(model_b).to receive(:column_names).and_return(['id', 'name'])
 
     subject.reconcile
 
     expect(index_a.sources.first.fields).to eq([field_a1, field_a2])
-    expect(index_b.fields).to eq([field_b1, field_b2])
+    expect(index_b.fields).to eq([field_b2])
   end
 end


### PR DESCRIPTION
Presently we only remove the class name field
if there's no index with inheritance at all
among the ones defined. This commit reconciles
all possible indices, skipping only the ones
where this field is needed.