### PR TITLE
Shift most tests to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,111 +16,6 @@ workflows:
             parameters:
               database: [ 'mysql2', 'postgresql' ]
               rails: [ '4_2', '5_0', '5_1', '5_2' ]
-      - test:
-          name: "Sphinx 3.4"
-          sphinx_version: 3.4.1
-          sphinx_engine: sphinx
-          debian: buster
-          matrix:
-            parameters:
-              database: [ 'mysql2' ]
-              ruby: [ '2.4.10', '2.5.9', '2.6.9', '2.7.5', '3.0.3' ]
-              rails: [ '4_2', '5_0', '5_1', '5_2' ]
-            exclude:
-              - rails: '4_2'
-                ruby: '2.5.9'
-              - rails: '4_2'
-                ruby: '2.6.9'
-              - rails: '4_2'
-                ruby: '2.7.5'
-              - rails: '4_2'
-                ruby: '3.0.3'
-              - rails: '5_0'
-                ruby: '3.0.3'
-              - rails: '5_1'
-                ruby: '3.0.3'
-              - rails: '5_2'
-                ruby: '3.0.3'
-              - rails: '6_0'
-                ruby: '2.4.10'
-              - rails: '6_1'
-                ruby: '2.4.10'
-              - rails: '7_0'
-                ruby: '2.4.10'
-              - rails: '7_0'
-                ruby: '2.5.9'
-              - rails: '7_0'
-                ruby: '2.6.9'
-      - test:
-          name: "Manticore 3.5"
-          sphinx_version: 3.5.4
-          sphinx_engine: manticore
-          debian: buster
-          matrix:
-            parameters:
-              database: [ 'mysql2', 'postgresql' ]
-              ruby: [ '2.4.10', '2.5.9', '2.6.9', '2.7.5', '3.0.3' ]
-              rails: [ '4_2', '5_0', '5_1', '5_2' ]
-            exclude:
-              - rails: '4_2'
-                ruby: '2.5.9'
-              - rails: '4_2'
-                ruby: '2.6.9'
-              - rails: '4_2'
-                ruby: '2.7.5'
-              - rails: '4_2'
-                ruby: '3.0.3'
-              - rails: '5_0'
-                ruby: '3.0.3'
-              - rails: '5_1'
-                ruby: '3.0.3'
-              - rails: '5_2'
-                ruby: '3.0.3'
-              - rails: '6_0'
-                ruby: '2.4.10'
-              - rails: '6_1'
-                ruby: '2.4.10'
-              - rails: '7_0'
-                ruby: '2.4.10'
-              - rails: '7_0'
-                ruby: '2.5.9'
-              - rails: '7_0'
-                ruby: '2.6.9'
-      - test:
-          name: "Manticore 4.0"
-          sphinx_version: 4.0.2
-          sphinx_engine: manticore
-          debian: buster
-          matrix:
-            parameters:
-              database: [ 'mysql2', 'postgresql' ]
-              ruby: [ '2.4.10', '2.5.9', '2.6.9', '2.7.5', '3.0.3' ]
-              rails: [ '4_2', '5_0', '5_1', '5_2' ]
-            exclude:
-              - rails: '4_2'
-                ruby: '2.5.9'
-              - rails: '4_2'
-                ruby: '2.6.9'
-              - rails: '4_2'
-                ruby: '2.7.5'
-              - rails: '4_2'
-                ruby: '3.0.3'
-              - rails: '5_0'
-                ruby: '3.0.3'
-              - rails: '5_1'
-                ruby: '3.0.3'
-              - rails: '5_2'
-                ruby: '3.0.3'
-              - rails: '6_0'
-                ruby: '2.4.10'
-              - rails: '6_1'
-                ruby: '2.4.10'
-              - rails: '7_0'
-                ruby: '2.4.10'
-              - rails: '7_0'
-                ruby: '2.5.9'
-              - rails: '7_0'
-                ruby: '2.6.9'
 
 jobs:
   test:
@@ -164,13 +59,7 @@ jobs:
       - run:
           name: install bundler
           command: |
-            if [ "<< parameters.ruby >>" == "2.7.5" ]; then
-              export BUNDLER_VERSION=2.1.4
-            elif [ "<< parameters.ruby >>" == "3.0.3" ]; then
-              export BUNDLER_VERSION=2.1.4
-            else
-              export BUNDLER_VERSION=1.17.3
-            fi
+            export BUNDLER_VERSION=1.17.3
             export BUNDLE_PATH=vendor/bundle
             gem install bundler:$BUNDLER_VERSION
 
@@ -188,11 +77,7 @@ jobs:
           name: update gems
           environment:
             BUNDLE_GEMFILE: "./gemfiles/rails_<< parameters.rails >>.gemfile"
-          command: |
-            if [[ -f $BUNDLE_GEMFILE ]]
-            then
-                bundle update
-            fi
+          command: bundle update
 
       - save_cache:
           paths:
@@ -211,8 +96,4 @@ jobs:
             SPHINX_VERSION: << parameters.sphinx_version >>
             SPHINX_ENGINE: << parameters.sphinx_engine >>
             BUNDLE_GEMFILE: "./gemfiles/rails_<< parameters.rails >>.gemfile"
-          command: |
-            if [[ -f $BUNDLE_GEMFILE ]]
-            then
-                bundle exec rspec
-            fi
+          command: bundle exec rspec

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,46 @@
+name: "Test"
+description: "Run RSpec in given environment"
+inputs:
+  ruby-version:
+    description: "Ruby version"
+    required: true
+  rails-version:
+    description: "Rails version"
+    required: true
+  sphinx-version:
+    description: "Sphinx version"
+    required: true
+  sphinx-engine:
+    description: "Sphinx engine"
+    required: true
+  database:
+    description: "Database engine"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler-cache: true
+    - name: Set up Sphinx
+      shell: bash
+      run: |
+        ./bin/loadsphinx ${{ inputs.sphinx-version }} ${{ inputs.sphinx-engine }}
+    - name: Set up Appraisal
+      shell: bash
+      run: "bundle exec appraisal generate"
+    - name: Install Appraisal's gems
+      shell: bash
+      env:
+        BUNDLE_GEMFILE: "gemfiles/rails_${{ inputs.rails-version }}.gemfile"
+      run: bundle install
+    - name: Test
+      shell: bash
+      env:
+        CI: "true"
+        DATABASE: ${{ inputs.database }}
+        SPHINX_VERSION: ${{ inputs.sphinx-version }}
+        SPHINX_ENGINE: ${{ inputs.sphinx-engine }}
+        BUNDLE_GEMFILE: "gemfiles/rails_${{ inputs.rails-version }}.gemfile"
+      run: "bundle exec rspec"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: test
+
+on: [push, pull_request]
+
+jobs:
+  sphinx:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-18.04' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        rails: [ '5_0', '5_1', '5_2', '6_0', '6_1', '7_0' ]
+        database: [ 'mysql2', 'postgresql' ]
+        sphinx_version: [ '3.4.1' ]
+        sphinx_engine: [ 'sphinx' ]
+        exclude:
+          - database: 'postgresql'
+            sphinx_version: '3.4.1'
+            sphinx_engine: 'sphinx'
+          - ruby: '2.5'
+            rails: '7_0'
+          - ruby: '2.6'
+            rails: '7_0'
+          - ruby: '3.0'
+            rails: '5_0'
+          - ruby: '3.0'
+            rails: '5_1'
+          - ruby: '3.0'
+            rails: '5_2'
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: thinking_sphinx
+          POSTGRES_DB: thinking_sphinx
+        ports: ['5432:5432']
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: thinking_sphinx
+          MYSQL_DATABASE: thinking_sphinx
+        ports: ['3306:3306']
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/test
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          rails-version: ${{ matrix.rails }}
+          sphinx-version: ${{ matrix.sphinx_version }}
+          sphinx-engine: ${{ matrix.sphinx_engine }}
+          database: ${{ matrix.database }}
+        timeout-minutes: 12
+
+  manticore:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        rails: [ '5_0', '5_1', '5_2', '6_0', '6_1', '7_0' ]
+        database: [ 'mysql2', 'postgresql' ]
+        sphinx_version: [ '3.5.4', '4.0.2' ]
+        sphinx_engine: [ 'manticore' ]
+        exclude:
+          - ruby: '2.5'
+            rails: '7_0'
+          - ruby: '2.6'
+            rails: '7_0'
+          - ruby: '3.0'
+            rails: '5_0'
+          - ruby: '3.0'
+            rails: '5_1'
+          - ruby: '3.0'
+            rails: '5_2'
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: thinking_sphinx
+          POSTGRES_DB: thinking_sphinx
+        ports: ['5432:5432']
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: thinking_sphinx
+          MYSQL_DATABASE: thinking_sphinx
+        ports: ['3306:3306']
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/test
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          rails-version: ${{ matrix.rails }}
+          sphinx-version: ${{ matrix.sphinx_version }}
+          sphinx-engine: ${{ matrix.sphinx_engine }}
+          database: ${{ matrix.database }}
+        timeout-minutes: 12

--- a/bin/loadsphinx
+++ b/bin/loadsphinx
@@ -66,14 +66,15 @@ load_manticore () {
     3.4.2)
       url="https://github.com/manticoresoftware/manticoresearch/releases/download/3.4.2/manticore_3.4.2-200410-6903305-release.xenial_amd64-bin.deb";;
     3.5.4)
-      url="https://repo.manticoresearch.com/repository/manticoresearch_buster/dists/buster/main/binary-amd64/manticore_3.5.4-210107-f70faec5_amd64.deb";;
+      url="https://repo.manticoresearch.com/repository/manticoresearch_focal/dists/focal/main/binary-amd64/manticore_3.5.4-210107-f70faec5_amd64.deb";;
     4.0.2)
-      url="https://repo.manticoresearch.com/repository/manticoresearch_buster/dists/buster/main/binary-amd64/manticore_4.0.2-210921-af497f245_amd64.deb";;
+      url="https://repo.manticoresearch.com/repository/manticoresearch_focal/dists/focal/main/binary-amd64/manticore_4.0.2-210921-af497f245_amd64.deb";;
     *)
       echo "No Manticore version $version available"
       exit 1;;
   esac
 
+  sudo apt-get install default-libmysqlclient-dev
   curl --location $url -o manticore.deb
   sudo dpkg -i ./manticore.deb
   sudo apt-get install -f


### PR DESCRIPTION
Now that GitHub Actions allows for retrying of failed jobs only, the switch is viable. That said, we’re going to keep using Circle CI for Sphinx 2.2.11, as GitHub no longer supports Ubuntu 16 (and Sphinx v2.2 doesn’t work on anything newer).

The added advantage of this is that we can keep Ruby v2.4, Rails v4.2, and Bundler v1 to just the Circle CI build, and v2.5+, v5.0+, and v2+ respectively on GitHub. Also, I've split the Manticore and Sphinx sections up, because Manticore requires MySQL v8, whereas we probably still want to use v5.7 with Sphinx (certainly for v2.2.11).