### PR TITLE
fix: convert File.exists? to File.exist?

### DIFF
--- a/lib/thinking_sphinx/commands/clear_real_time.rb
+++ b/lib/thinking_sphinx/commands/clear_real_time.rb
@@ -7,7 +7,7 @@ class ThinkingSphinx::Commands::ClearRealTime < ThinkingSphinx::Commands::Base
       Dir["#{index.path}.*"].each { |path| FileUtils.rm path }
     end
 
-    FileUtils.rm_r(binlog_path) if File.exists?(binlog_path)
+    FileUtils.rm_r(binlog_path) if File.exist?(binlog_path)
   end
 
   private

--- a/lib/thinking_sphinx/guard/file.rb
+++ b/lib/thinking_sphinx/guard/file.rb
@@ -12,7 +12,7 @@ class ThinkingSphinx::Guard::File
   end
 
   def locked?
-    File.exists? path
+    File.exist? path
   end
 
   def path

--- a/lib/thinking_sphinx/settings.rb
+++ b/lib/thinking_sphinx/settings.rb
@@ -35,7 +35,7 @@ class ThinkingSphinx::Settings
   end
 
   def call
-    return defaults unless File.exists? file
+    return defaults unless File.exist? file
 
     merged.inject({}) do |hash, (key, value)|
       if absolute_key?(key)

--- a/spec/support/sphinx_yaml_helpers.rb
+++ b/spec/support/sphinx_yaml_helpers.rb
@@ -2,7 +2,7 @@
 
 module SphinxYamlHelpers
   def write_configuration(hash)
-    allow(File).to receive_messages :read => {'test' => hash}.to_yaml, :exists? => true
+    allow(File).to receive_messages :read => {'test' => hash}.to_yaml, :exist? => true, :exists? => true
   end
 end
 

--- a/spec/thinking_sphinx/commands/clear_real_time_spec.rb
+++ b/spec/thinking_sphinx/commands/clear_real_time_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ThinkingSphinx::Commands::ClearRealTime do
 
     allow(FileUtils).to receive_messages :rm_r => true,
       :rm => true
-    allow(File).to receive_messages :exists? => true
+    allow(File).to receive_messages :exist? => true
   end
 
   it 'finds each file for real-time indices' do

--- a/spec/thinking_sphinx/commands/clear_sql_spec.rb
+++ b/spec/thinking_sphinx/commands/clear_sql_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ThinkingSphinx::Commands::ClearSQL do
       and_return(['/path/to/indices/ts-foo.tmp'])
 
     allow(FileUtils).to receive_messages :rm_r => true, :rm => true
-    allow(File).to receive_messages :exists? => true
+    allow(File).to receive_messages :exist? => true
   end
 
   it 'finds each file for sql-backed indices' do

--- a/spec/thinking_sphinx/configuration_spec.rb
+++ b/spec/thinking_sphinx/configuration_spec.rb
@@ -38,7 +38,7 @@ describe ThinkingSphinx::Configuration do
     end
 
     it 'does not cache settings after reset' do
-      allow(File).to receive_messages :exists? => true
+      allow(File).to receive_messages :exist? => true
       allow(File).to receive_messages :read => {
         'test'       => {'foo' => 'bugs'},
         'production' => {'foo' => 'bar'}
@@ -504,7 +504,7 @@ describe ThinkingSphinx::Configuration do
   describe '#settings' do
     context 'YAML file exists' do
       before :each do
-        allow(File).to receive_messages :exists? => true
+        allow(File).to receive_messages :exist? => true
       end
 
       it "reads from the YAML file" do
@@ -540,7 +540,7 @@ describe ThinkingSphinx::Configuration do
 
     context 'YAML file does not exist' do
       before :each do
-        allow(File).to receive_messages :exists? => false
+        allow(File).to receive_messages :exist? => false
       end
 
       it "does not read the file" do


### PR DESCRIPTION
File.exists? is deprecated and issues warning messages when run. One
instance was already updates in
f4973b4ab172d222df57972780935d4fa47ef730 for #1211. This commit
updates the remaining use of File.exists?