### PR TITLE
Updating GitHub CI build matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,21 +74,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         rails: [ '5_0', '5_1', '5_2', '6_0', '6_1', '7_0' ]
         database: [ 'mysql2', 'postgresql' ]
         sphinx_version: [ '3.5.4', '4.0.2' ]
         sphinx_engine: [ 'manticore' ]
         exclude:
-          - ruby: '2.5'
-            rails: '7_0'
-          - ruby: '2.6'
-            rails: '7_0'
           - ruby: '3.0'
             rails: '5_0'
           - ruby: '3.0'
             rails: '5_1'
           - ruby: '3.0'
+            rails: '5_2'
+          - ruby: '3.1'
+            rails: '5_0'
+          - ruby: '3.1'
+            rails: '5_1'
+          - ruby: '3.1'
+            rails: '5_2'
+          - ruby: '3.2'
+            rails: '5_0'
+          - ruby: '3.2'
+            rails: '5_1'
+          - ruby: '3.2'
             rails: '5_2'
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         rails: [ '5_0', '5_1', '5_2', '6_0', '6_1', '7_0' ]
         database: [ 'mysql2', 'postgresql' ]
-        sphinx_version: [ '3.4.1' ]
+        sphinx_version: [ '2.2.11', '3.4.1' ]
         sphinx_engine: [ 'sphinx' ]
         exclude:
           - database: 'postgresql'

--- a/bin/loadsphinx
+++ b/bin/loadsphinx
@@ -15,7 +15,8 @@ load_sphinx () {
       distro="trusty";;
     2.2.11)
       url="http://sphinxsearch.com/files/sphinxsearch_2.2.11-release-1~jessie_amd64.deb"
-      format="deb";;
+      format="deb"
+      distro="trusty";;
     3.0.3)
       url="http://sphinxsearch.com/files/sphinx-3.0.3-facc3fb-linux-amd64.tar.gz"
       format="gz";;


### PR DESCRIPTION
This updates Github CI to include sphinx 2.2.11, and updates the list of supported rubies to test manticore against.

Sphinx 2 does work ok, AFAICT, though a few times it hit the 12 minute timeout. Re-running the action fixed it.

I did experiment with removing the extra `sleep` calls we use with `ENV['CI']` - seemed like the manticore tests were fine with it, but it did cause a few extra sphinx failures.

After this update, we have 60 manticore test runs, and 45 sphinx, which seems quite a lot. Is it worth thinking about dropping Rails 5.x support? Or at least 5.0 & 5.1 ?

Want me to remove the Travis & CircleCI config, or are they still useful after this?