### PR TITLE
Set a default cutoff for Manticore.

### DIFF
--- a/lib/thinking_sphinx/settings.rb
+++ b/lib/thinking_sphinx/settings.rb
@@ -20,7 +20,8 @@ class ThinkingSphinx::Settings
     "workers"                  => "threads",
     "mysql_encoding"           => "utf8",
     "maximum_statement_length" => (2 ** 23) - 5,
-    "real_time_tidy"           => false
+    "real_time_tidy"           => false,
+    "cutoff"                   => 0
   }.freeze
   YAML_SAFE_LOAD = YAML.method(:safe_load).parameters.any? do |parameter|
     parameter == [:key, :aliases]


### PR DESCRIPTION
Since Manticore 5.0, their default cutoff is the same as the search request’s page size - which helps make search requests faster. The unfortunate trade-off is that it means pagination breaks because we no longer know what the actual total number of results is (Manticore stops counting once the cutoff is reached).

So, at least for now, we’re going to set a default cutoff of 0, which essentially removes that limit. Judging by the CI results, Sphinx is fine with this too.