### PR TITLE
Allow disabling auto extending ActiveRecord::Base

### DIFF
--- a/lib/thinking_sphinx/active_record.rb
+++ b/lib/thinking_sphinx/active_record.rb
@@ -41,4 +41,6 @@ require 'thinking_sphinx/active_record/depolymorph/overridden_reflection'
 require 'thinking_sphinx/active_record/depolymorph/scoped_reflection'
 require 'thinking_sphinx/active_record/filter_reflection'
 
-ActiveRecord::Base.include ThinkingSphinx::ActiveRecord::Base
+if ThinkingSphinx::Configuration.new.settings.fetch("extend_active_record_base")
+  ActiveRecord::Base.include ThinkingSphinx::ActiveRecord::Base
+end

--- a/lib/thinking_sphinx/settings.rb
+++ b/lib/thinking_sphinx/settings.rb
@@ -21,7 +21,8 @@ class ThinkingSphinx::Settings
     "mysql_encoding"           => "utf8",
     "maximum_statement_length" => (2 ** 23) - 5,
     "real_time_tidy"           => false,
-    "cutoff"                   => 0
+    "cutoff"                   => 0,
+    "extend_active_record_base" => true
   }.freeze
   YAML_SAFE_LOAD = YAML.method(:safe_load).parameters.any? do |parameter|
     parameter == [:key, :aliases]


### PR DESCRIPTION
Method names like `.search` can collide with existing scopes which then results in the following error:

```
You tried to define a scope named "search" on the model "…", but Active
Record already defined a class method with the same name.
```

With that setting being set to `false` it allows one to enable ThinkingSphinx per model instead of globally.