### PR TITLE
build: test against Manticore 6.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         rails: [ '5_0', '5_1', '5_2', '6_0', '6_1', '7_0' ]
         database: [ 'mysql2', 'postgresql' ]
-        sphinx_version: [ '3.5.4', '4.0.2' ]
+        sphinx_version: [ '4.0.2', '6.0.0' ]
         sphinx_engine: [ 'manticore' ]
         exclude:
           - ruby: '3.0'

--- a/README.textile
+++ b/README.textile
@@ -31,7 +31,7 @@ The current release of Thinking Sphinx works with the following versions of its 
 |_. Library |_. Minimum |_. Tested Against |
 | Ruby | v2.4 | v2.4, v2.5, v2.6, v2.7, v3.0, v3.1, v3.2 |
 | Sphinx | v2.2.11 | v2.2.11, v3.4.1 |
-| Manticore | v2.8 | v3.5, v4.0 |
+| Manticore | v2.8 | v4.0, v6.0 |
 | ActiveRecord | v4.2 | v4.2..v7.0 |
 
 It _might_ work with older versions of Ruby, but it's highly recommended to update to a supported release.
@@ -42,7 +42,7 @@ h3. Sphinx or Manticore
 
 If you're using Sphinx, v2.2.11 is recommended even though it's quite old, as it works well with PostgreSQL databases (but if you're using MySQL - or real-time indices - then v3.3.1 should also be fine).
 
-If you're opting for Manticore instead, v2.8 or newer works, but v3 or newer is recommended as that's what is actively tested against.
+If you're opting for Manticore instead, v2.8 or newer works, but v4 or newer is recommended as that's what is actively tested against. The v4.2 and 5.0 releases had bugs with facet searching, but that's been fixed in Manticore v6.0.
 
 h3. Rails and ActiveRecord
 

--- a/bin/loadsphinx
+++ b/bin/loadsphinx
@@ -70,15 +70,26 @@ load_manticore () {
       url="https://repo.manticoresearch.com/repository/manticoresearch_focal/dists/focal/main/binary-amd64/manticore_3.5.4-210107-f70faec5_amd64.deb";;
     4.0.2)
       url="https://repo.manticoresearch.com/repository/manticoresearch_focal/dists/focal/main/binary-amd64/manticore_4.0.2-210921-af497f245_amd64.deb";;
+    4.2.0)
+      url="https://repo.manticoresearch.com/repository/manticoresearch_focal/dists/focal/main/binary-amd64/manticore_4.2.0-211223-15e927b28_amd64.deb";;
+    6.0.0)
+      url="skipped";;
     *)
       echo "No Manticore version $version available"
       exit 1;;
   esac
 
-  sudo apt-get install default-libmysqlclient-dev
-  curl --location $url -o manticore.deb
-  sudo dpkg -i ./manticore.deb
-  sudo apt-get install -f
+  if [ "$version" == "6.0.0" ]; then
+    curl --location https://repo.manticoresearch.com/manticore-repo.noarch.deb -o repo.deb
+    sudo dpkg -i repo.deb
+    sudo apt update
+    sudo apt install manticore
+  else
+    sudo apt-get install default-libmysqlclient-dev
+    curl --location $url -o manticore.deb
+    sudo dpkg -i ./manticore.deb
+    sudo apt-get install -f
+  fi
 }
 
 if [ "$engine" == "sphinx" ]; then


### PR DESCRIPTION
There are 4.2 and 5.0 releases as well, but they have a bug with facet searches (which wasn’t fixed until now, as there were no 5.1 releases).