### PR TITLE
feat: add postgis adapter support

### DIFF
--- a/lib/thinking_sphinx/active_record/database_adapters.rb
+++ b/lib/thinking_sphinx/active_record/database_adapters.rb
@@ -14,7 +14,7 @@ module ThinkingSphinx::ActiveRecord::DatabaseAdapters
       when :postgresql
         PostgreSQLAdapter
       else
-        raise ThinkingSphinx::InvalidDatabaseAdapter, "Invalid adapter '#{adapter}': Thinking Sphinx only supports MySQL and PostgreSQL."
+        raise ThinkingSphinx::InvalidDatabaseAdapter, "Invalid adapter '#{adapter}': Thinking Sphinx only supports MySQL, PostgreSQL and PostGIS."
       end
 
       klass.new model
@@ -25,7 +25,7 @@ module ThinkingSphinx::ActiveRecord::DatabaseAdapters
       case class_name.split('::').last
       when 'MysqlAdapter', 'Mysql2Adapter'
         :mysql
-      when 'PostgreSQLAdapter'
+      when 'PostgreSQLAdapter', 'PostGISAdapter'
         :postgresql
       when 'JdbcAdapter'
         adapter_type_for_jdbc(model)

--- a/spec/thinking_sphinx/active_record/database_adapters_spec.rb
+++ b/spec/thinking_sphinx/active_record/database_adapters_spec.rb
@@ -75,6 +75,13 @@ describe ThinkingSphinx::ActiveRecord::DatabaseAdapters do
         adapter_type_for(model)).to eq(:postgresql)
     end
 
+    it "translates a normal PostGIS adapter" do
+      allow(klass).to receive_messages(:name => 'ActiveRecord::ConnectionAdapters::PostGISAdapter')
+
+      expect(ThinkingSphinx::ActiveRecord::DatabaseAdapters.
+        adapter_type_for(model)).to eq(:postgresql)
+    end
+
     it "translates a JDBC MySQL adapter to MySQL" do
       allow(klass).to receive_messages(:name => 'ActiveRecord::ConnectionAdapters::JdbcAdapter')
       allow(connection).to receive_messages(:config => {:adapter => 'jdbcmysql'})


### PR DESCRIPTION
Requests to the database through postgresql adapters and postgis adapters are identical, and it would be more convenient if it were not necessary to write the initializer config, which you advised for the example in this pull request https://github.com/pat/thinking-sphinx/pull/828