### PR TITLE
handle rt and plain indices the same

### DIFF
--- a/lib/thinking_sphinx/configuration/minimum_fields.rb
+++ b/lib/thinking_sphinx/configuration/minimum_fields.rb
@@ -18,19 +18,19 @@ class ThinkingSphinx::Configuration::MinimumFields
   attr_reader :indices
 
   def field_collections
-    plain_indices_without_inheritance.collect(&:sources).flatten +
-    indices_of_type('rt')
-  end
-
-  def indices_of_type(type)
-    indices.select { |index| index.type == type }
+    indices_without_inheritance_of_type('plain').collect(&:sources).flatten +
+      indices_without_inheritance_of_type('rt')
   end
 
   def inheritance_columns?(index)
     index.model.table_exists? && index.model.column_names.include?(index.model.inheritance_column)
   end
 
-  def plain_indices_without_inheritance
-    indices_of_type('plain').reject(&method(:inheritance_columns?))
+  def indices_without_inheritance_of_type(type)
+    indices_without_inheritance.select { |index| index.type == type }
+  end
+
+  def indices_without_inheritance
+    indices.reject(&method(:inheritance_columns?))
   end
 end

--- a/spec/thinking_sphinx/configuration/minimum_fields_spec.rb
+++ b/spec/thinking_sphinx/configuration/minimum_fields_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ThinkingSphinx::Configuration::MinimumFields do
   let(:indices) { [index_a, index_b] }
   let(:index_a) { double 'Index A', :model => model_a, :type => 'plain',
     :sources => [double(:fields => [field_a1, field_a2])] }
-  let(:index_b) { double 'Index B', :model => model_a, :type => 'rt',
+  let(:index_b) { double 'Index B', :model => model_b, :type => 'rt',
     :fields => [field_b1, field_b2] }
   let(:field_a1) { double :name => 'sphinx_internal_class_name' }
   let(:field_a2) { double :name => 'name' }
@@ -38,7 +38,7 @@ RSpec.describe ThinkingSphinx::Configuration::MinimumFields do
     expect(index_b.fields).to eq([field_b2])
   end
 
-  it 'removes the class name fields only for the indices without type column' do
+  it 'removes the class name fields only for the rt indices without type column' do
     allow(model_a).to receive(:column_names).and_return(['id', 'name', 'type'])
     allow(model_b).to receive(:column_names).and_return(['id', 'name'])
 
@@ -46,5 +46,15 @@ RSpec.describe ThinkingSphinx::Configuration::MinimumFields do
 
     expect(index_a.sources.first.fields).to eq([field_a1, field_a2])
     expect(index_b.fields).to eq([field_b2])
+  end
+
+  it 'removes the class name fields only for the plain indices without type column' do
+    allow(model_a).to receive(:column_names).and_return(['id', 'name'])
+    allow(model_b).to receive(:column_names).and_return(['id', 'name', 'type'])
+
+    subject.reconcile
+
+    expect(index_a.sources.first.fields).to eq([field_a2])
+    expect(index_b.fields).to eq([field_b1, field_b2])
   end
 end


### PR DESCRIPTION
because of my oversight in #1222 all rt indices lost the `sphinx_internal_class_name` field and this is not correct. In either index type, when single table inheritance is used, then `sphinx_internal_class_name` should be present. Now also added a test for it - to make sure both index types are handled.