### PR TITLE
Fix links to Riddle in docs homepages

### DIFF
--- a/v3/index.md
+++ b/v3/index.md
@@ -20,7 +20,7 @@ Read up on [installing Sphinx](installing_sphinx.html) and [then Thinking Sphinx
 
 ### Who?
 
-[Pat Allan](http://freelancing-gods.com) is the developer behind Thinking Sphinx, and the underlying API for Sphinx, [Riddle](http://pat.github.com/riddle). [Many others](https://github.com/pat/thinking-sphinx/contributors) have contributed valued patches and ideas.
+[Pat Allan](http://freelancing-gods.com) is the developer behind Thinking Sphinx, and the underlying API for Sphinx, [Riddle](https://freelancing-gods.com/riddle/). [Many others](https://github.com/pat/thinking-sphinx/contributors) have contributed valued patches and ideas.
 
 ### Most importantly: How?
 

--- a/v4/index.md
+++ b/v4/index.md
@@ -20,7 +20,7 @@ Read up on [installing Sphinx](installing_sphinx.html) and [then Thinking Sphinx
 
 ### Who?
 
-[Pat Allan](http://freelancing-gods.com) is the developer behind Thinking Sphinx, and the underlying API for Sphinx, [Riddle](http://pat.github.com/riddle). [Many, many others](https://github.com/pat/thinking-sphinx/contributors) have contributed valued patches and ideas.
+[Pat Allan](http://freelancing-gods.com) is the developer behind Thinking Sphinx, and the underlying API for Sphinx, [Riddle](https://freelancing-gods.com/riddle/). [Many, many others](https://github.com/pat/thinking-sphinx/contributors) have contributed valued patches and ideas.
 
 ### Most importantly: How?
 

--- a/v5/index.md
+++ b/v5/index.md
@@ -21,7 +21,7 @@ Read up on [installing Sphinx](installing_sphinx.html) and [then Thinking Sphinx
 
 ### Who?
 
-[Pat Allan](http://freelancing-gods.com) is the developer behind Thinking Sphinx, and the underlying API for Sphinx, [Riddle](http://pat.github.com/riddle). [Many, many others](https://github.com/pat/thinking-sphinx/contributors) have contributed valued patches and ideas.
+[Pat Allan](http://freelancing-gods.com) is the developer behind Thinking Sphinx, and the underlying API for Sphinx, [Riddle](https://freelancing-gods.com/riddle/). [Many, many others](https://github.com/pat/thinking-sphinx/contributors) have contributed valued patches and ideas.
 
 ### Most importantly: How?
 


### PR DESCRIPTION
`http://pat.github.com/riddle` [gives a 404](https://pat.github.com/riddle). I didn't know user sites were ever available at *.github.com. I could've just updated the links to be `pat.github.io/riddle`, but that redirects, so I've just used the destination.

You might have other places to change from `.com` to `.io` - e.g. the repo name and description of https://github.com/pat/pat.github.com