### PR TITLE
scope based upsert or delete

### DIFF
--- a/lib/thinking_sphinx/processor.rb
+++ b/lib/thinking_sphinx/processor.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ThinkingSphinx::Processor
+  # @param instance [ActiveRecord::Base] an ActiveRecord object
+  # @param model [Class] the ActiveRecord model of the instance
+  # @param id [Integer] the instance indices primary key (might be different from model primary key)
   def initialize(instance: nil, model: nil, id: nil)
     raise ArgumentError if instance.nil? && (model.nil? || id.nil?)
 
@@ -12,16 +15,27 @@ class ThinkingSphinx::Processor
   def delete
     return if instance&.new_record?
 
-    indices.each { |index|
-      ThinkingSphinx::Deletion.perform(
-        index, id || instance.public_send(index.primary_key)
-      )
-    }
+    indices.each { |index| perform_deletion(index) }
   end
 
+  # Will insert instance into all matching indices
   def upsert
     real_time_indices.each do |index|
-      ThinkingSphinx::RealTime::Transcriber.new(index).copy loaded_instance
+      found = loaded_instance(index)
+      ThinkingSphinx::RealTime::Transcriber.new(index).copy found if found
+    end
+  end
+
+  # Will upsert or delete instance into all matching indices based on index scope
+  def stage
+    real_time_indices.each do |index|
+      found = find_in(index)
+
+      if found
+        ThinkingSphinx::RealTime::Transcriber.new(index).copy found
+      else
+        ThinkingSphinx::Deletion.perform(index, index_id(index))
+      end
     end
   end
 
@@ -35,11 +49,23 @@ class ThinkingSphinx::Processor
     ).to_a
   end
 
-  def loaded_instance
-    @loaded_instance ||= instance || model.find(id)
+  def find_in(index)
+    index.scope.find_by(index.primary_key => index_id(index))
+  end
+
+  def loaded_instance(index)
+    instance || find_in(index)
   end
 
   def real_time_indices
     indices.select { |index| index.is_a? ThinkingSphinx::RealTime::Index }
+  end
+
+  def perform_deletion(index)
+    ThinkingSphinx::Deletion.perform(index, index_id(index))
+  end
+
+  def index_id(index)
+    id || instance.public_send(index.primary_key)
   end
 end

--- a/spec/internal/app/indices/article_index.rb
+++ b/spec/internal/app/indices/article_index.rb
@@ -23,3 +23,9 @@ ThinkingSphinx::Index.define :article, :with => :active_record,
 
   set_property :morphology => 'stem_en'
 end
+
+ThinkingSphinx::Index.define :article, :name => :published_articles, :with => :real_time do
+  indexes title, content
+
+  scope { Article.where :published => true }
+end


### PR DESCRIPTION
When an index is defined, one can specify a scope. This scope is used to obtain records on initial indexing (ts:index) but is not respected by the model callbacks.

With this additional method one can easily implement ActiveRecord callbacks e.g.
```rb
    after_commit :index_object

    def index_object
      ThinkingSphinx::Processor.new(instance: instance).stage
    end
```

A little bit more efficient (preventing a database roundtrip on deletes
```rb
    after_commit :index_object, :on => %i(create update)
    after_commit :deindex_object, :on => :destroy

    def index_object
      ThinkingSphinx::Processor.new(instance: self).stage
    end

    def deindex_object
      ThinkingSphinx::Processor.new(instance: self).delete
    end
```

If certain models never use scopes for their indices, then `#upsert` can be called instead of `#stage` to avoid database roundtrips.

While on it, example background processing of indexing operations e.g.
```rb
    after_commit :background_index_object

    def background_index_object
      ThinkingIndexationWorker.perform_later(self.class, id) # call ThinkingSphinx::Processor#stage in worker
    end
```

fixes #1253
complements #1216 and #1215