### PR TITLE
Fixing CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/test
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,11 @@ on: [push, pull_request]
 
 jobs:
   sphinx:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-18.04' ]
         ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         rails: [ '5_0', '5_1', '5_2', '6_0', '6_1', '7_0' ]
         database: [ 'mysql2', 'postgresql' ]
@@ -69,7 +68,7 @@ jobs:
         timeout-minutes: 12
 
   manticore:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/spec/acceptance/attribute_access_spec.rb
+++ b/spec/acceptance/attribute_access_spec.rb
@@ -4,17 +4,17 @@ require 'acceptance/spec_helper'
 
 describe 'Accessing attributes directly via search results', :live => true do
   it "allows access to attribute values" do
-    Book.create! :title => 'American Gods', :year => 2001
+    Book.create! :title => 'American Gods', :publishing_year => 2001
     index
 
     search = Book.search('gods')
     search.context[:panes] << ThinkingSphinx::Panes::AttributesPane
 
-    expect(search.first.sphinx_attributes['year']).to eq(2001)
+    expect(search.first.sphinx_attributes['publishing_year']).to eq(2001)
   end
 
   it "provides direct access to the search weight/relevance scores" do
-    Book.create! :title => 'American Gods', :year => 2001
+    Book.create! :title => 'American Gods', :publishing_year => 2001
     index
 
     search = Book.search 'gods', :select => "*, weight()"
@@ -37,7 +37,7 @@ describe 'Accessing attributes directly via search results', :live => true do
   end
 
   it "can enumerate with the weight" do
-    gods = Book.create! :title => 'American Gods', :year => 2001
+    gods = Book.create! :title => 'American Gods', :publishing_year => 2001
     index
 
     search = Book.search 'gods', :select => "*, weight()"

--- a/spec/acceptance/excerpts_spec.rb
+++ b/spec/acceptance/excerpts_spec.rb
@@ -5,7 +5,7 @@ require 'acceptance/spec_helper'
 
 describe 'Accessing excerpts for methods on a search result', :live => true do
   it "returns excerpts for a given method" do
-    Book.create! :title => 'American Gods', :year => 2001
+    Book.create! :title => 'American Gods', :publishing_year => 2001
     index
 
     search = Book.search('gods')
@@ -16,7 +16,7 @@ describe 'Accessing excerpts for methods on a search result', :live => true do
   end
 
   it "handles UTF-8 text for excerpts" do
-    Book.create! :title => 'Война и миръ', :year => 1869
+    Book.create! :title => 'Война и миръ', :publishing_year => 1869
     index
 
     search = Book.search 'миръ'

--- a/spec/acceptance/grouping_by_attributes_spec.rb
+++ b/spec/acceptance/grouping_by_attributes_spec.rb
@@ -4,36 +4,36 @@ require 'acceptance/spec_helper'
 
 describe 'Grouping search results by attributes', :live => true do
   it "groups by the provided attribute" do
-    snuff  = Book.create! :title => 'Snuff',          :year => 2011
-    earth  = Book.create! :title => 'The Long Earth', :year => 2012
-    dodger = Book.create! :title => 'Dodger',         :year => 2012
+    snuff  = Book.create! :title => 'Snuff',          :publishing_year => 2011
+    earth  = Book.create! :title => 'The Long Earth', :publishing_year => 2012
+    dodger = Book.create! :title => 'Dodger',         :publishing_year => 2012
 
     index
 
-    expect(Book.search(:group_by => :year).to_a).to eq([snuff, earth])
+    expect(Book.search(:group_by => :publishing_year).to_a).to eq([snuff, earth])
   end
 
   it "allows sorting within the group" do
-    snuff  = Book.create! :title => 'Snuff',          :year => 2011
-    earth  = Book.create! :title => 'The Long Earth', :year => 2012
-    dodger = Book.create! :title => 'Dodger',         :year => 2012
+    snuff  = Book.create! :title => 'Snuff',          :publishing_year => 2011
+    earth  = Book.create! :title => 'The Long Earth', :publishing_year => 2012
+    dodger = Book.create! :title => 'Dodger',         :publishing_year => 2012
 
     index
 
-    expect(Book.search(:group_by => :year, :order_group_by => 'title ASC').to_a).
+    expect(Book.search(:group_by => :publishing_year, :order_group_by => 'title ASC').to_a).
       to eq([snuff, dodger])
   end
 
   it "allows enumerating by count" do
-    snuff  = Book.create! :title => 'Snuff',          :year => 2011
-    earth  = Book.create! :title => 'The Long Earth', :year => 2012
-    dodger = Book.create! :title => 'Dodger',         :year => 2012
+    snuff  = Book.create! :title => 'Snuff',          :publishing_year => 2011
+    earth  = Book.create! :title => 'The Long Earth', :publishing_year => 2012
+    dodger = Book.create! :title => 'Dodger',         :publishing_year => 2012
 
     index
 
     expectations = [[snuff, 1], [earth, 2]]
 
-    Book.search(:group_by => :year).each_with_count do |book, count|
+    Book.search(:group_by => :publishing_year).each_with_count do |book, count|
       expectation = expectations.shift
 
       expect(book).to  eq(expectation.first)
@@ -42,15 +42,15 @@ describe 'Grouping search results by attributes', :live => true do
   end
 
   it "allows enumerating by group" do
-    snuff  = Book.create! :title => 'Snuff',          :year => 2011
-    earth  = Book.create! :title => 'The Long Earth', :year => 2012
-    dodger = Book.create! :title => 'Dodger',         :year => 2012
+    snuff  = Book.create! :title => 'Snuff',          :publishing_year => 2011
+    earth  = Book.create! :title => 'The Long Earth', :publishing_year => 2012
+    dodger = Book.create! :title => 'Dodger',         :publishing_year => 2012
 
     index
 
     expectations = [[snuff, 2011], [earth, 2012]]
 
-    Book.search(:group_by => :year).each_with_group do |book, group|
+    Book.search(:group_by => :publishing_year).each_with_group do |book, group|
       expectation = expectations.shift
 
       expect(book).to  eq(expectation.first)
@@ -59,14 +59,14 @@ describe 'Grouping search results by attributes', :live => true do
   end
 
   it "allows enumerating by group and count" do
-    snuff  = Book.create! :title => 'Snuff',          :year => 2011
-    earth  = Book.create! :title => 'The Long Earth', :year => 2012
-    dodger = Book.create! :title => 'Dodger',         :year => 2012
+    snuff  = Book.create! :title => 'Snuff',          :publishing_year => 2011
+    earth  = Book.create! :title => 'The Long Earth', :publishing_year => 2012
+    dodger = Book.create! :title => 'Dodger',         :publishing_year => 2012
 
     index
 
     expectations = [[snuff, 2011, 1], [earth, 2012, 2]]
-    search       = Book.search(:group_by => :year)
+    search       = Book.search(:group_by => :publishing_year)
 
     search.each_with_group_and_count do |book, group, count|
       expectation = expectations.shift

--- a/spec/acceptance/searching_with_filters_spec.rb
+++ b/spec/acceptance/searching_with_filters_spec.rb
@@ -12,12 +12,12 @@ describe 'Searching with filters', :live => true do
   end
 
   it "limits results by an array of values" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
     index
 
-    expect(Book.search(:with => {:year => [2001, 2005]}).to_a).to match_array([gods, boys])
+    expect(Book.search(:with => {:publishing_year => [2001, 2005]}).to_a).to match_array([gods, boys])
   end
 
   it "limits results by a ranged filter" do
@@ -43,12 +43,12 @@ describe 'Searching with filters', :live => true do
   end
 
   it "limits results by exclusive filters on arrays of values" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
     index
 
-    expect(Book.search(:without => {:year => [2001, 2005]}).to_a).to eq([grave])
+    expect(Book.search(:without => {:publishing_year => [2001, 2005]}).to_a).to eq([grave])
   end
 
   it "limits results by ranged filters on timestamp MVAs" do

--- a/spec/acceptance/sorting_search_results_spec.rb
+++ b/spec/acceptance/sorting_search_results_spec.rb
@@ -4,27 +4,27 @@ require 'acceptance/spec_helper'
 
 describe 'Sorting search results', :live => true do
   it "sorts by a given clause" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
     index
 
-    expect(Book.search(:order => 'year ASC').to_a).to eq([gods, boys, grave])
+    expect(Book.search(:order => 'publishing_year ASC').to_a).to eq([gods, boys, grave])
   end
 
   it "sorts by a given attribute in ascending order" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
     index
 
-    expect(Book.search(:order => :year).to_a).to eq([gods, boys, grave])
+    expect(Book.search(:order => :publishing_year).to_a).to eq([gods, boys, grave])
   end
 
   it "sorts by a given sortable field" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
     index
 
     expect(Book.search(:order => :title).to_a).to eq([gods, boys, grave])
@@ -38,13 +38,13 @@ describe 'Sorting search results', :live => true do
   end
 
   it "can sort with a provided expression" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
     index
 
     expect(Book.search(
-      :select => '*, year MOD 2004 as mod_year', :order => 'mod_year ASC'
+      :select => '*, publishing_year MOD 2004 as mod_year', :order => 'mod_year ASC'
     ).to_a).to eq([boys, grave, gods])
   end
 end

--- a/spec/acceptance/sphinx_scopes_spec.rb
+++ b/spec/acceptance/sphinx_scopes_spec.rb
@@ -4,39 +4,39 @@ require 'acceptance/spec_helper'
 
 describe 'Sphinx scopes', :live => true do
   it "allows calling sphinx scopes from models" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
     index
 
-    expect(Book.by_year(2009).to_a).to eq([grave])
+    expect(Book.by_publishing_year(2009).to_a).to eq([grave])
   end
 
   it "allows scopes to return both query and options" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
     index
 
-    expect(Book.by_query_and_year('Graveyard', 2009).to_a).to eq([grave])
+    expect(Book.by_query_and_publishing_year('Graveyard', 2009).to_a).to eq([grave])
   end
 
   it "allows chaining of scopes" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
     index
 
-    expect(Book.by_year(2001..2005).ordered.to_a).to eq([boys, gods])
+    expect(Book.by_publishing_year(2001..2005).ordered.to_a).to eq([boys, gods])
   end
 
   it "allows chaining of scopes that include queries" do
-    gods  = Book.create! :title => 'American Gods',      :year => 2001
-    boys  = Book.create! :title => 'Anansi Boys',        :year => 2005
-    grave = Book.create! :title => 'The Graveyard Book', :year => 2009
+    gods  = Book.create! :title => 'American Gods',      :publishing_year => 2001
+    boys  = Book.create! :title => 'Anansi Boys',        :publishing_year => 2005
+    grave = Book.create! :title => 'The Graveyard Book', :publishing_year => 2009
     index
 
-    expect(Book.by_year(2001).by_query_and_year('Graveyard', 2009).to_a).
+    expect(Book.by_publishing_year(2001).by_query_and_publishing_year('Graveyard', 2009).to_a).
       to eq([grave])
   end
 

--- a/spec/internal/app/indices/book_index.rb
+++ b/spec/internal/app/indices/book_index.rb
@@ -6,6 +6,6 @@ ThinkingSphinx::Index.define :book, :with => :active_record, :delta => true do
   indexes [title, author], :as => :info
   indexes blurb_file, :file => true
 
-  has year
+  has publishing_year
   has created_at, :type => :timestamp
 end

--- a/spec/internal/app/models/book.rb
+++ b/spec/internal/app/models/book.rb
@@ -8,11 +8,11 @@ class Book < ActiveRecord::Base
   ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql, :deltas])
 
   sphinx_scope(:by_query) { |query| query }
-  sphinx_scope(:by_year) do |year|
-    {:with => {:year => year}}
+  sphinx_scope(:by_publishing_year) do |year|
+    {:with => {:publishing_year => year}}
   end
-  sphinx_scope(:by_query_and_year) do |query, year|
-    [query, {:with => {:year =>year}}]
+  sphinx_scope(:by_query_and_publishing_year) do |query, year|
+    [query, {:with => {:publishing_year =>year}}]
   end
-  sphinx_scope(:ordered) { {:order => 'year DESC'} }
+  sphinx_scope(:ordered) { {:order => 'publishing_year DESC'} }
 end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define do
   create_table(:books, :force => true) do |t|
     t.string  :title
     t.string  :author
-    t.integer :year
+    t.integer :publishing_year
     t.string  :blurb_file
     t.boolean :delta, :default => true,   :null => false
     t.string  :type,  :default => 'Book', :null => false


### PR DESCRIPTION
This should get the CI all green again

* GHA has deprecated the ubuntu 18 runner, so I've updated to 22.
* Manticore has introduced a `year` keyword, which [apparently can't be escaped](https://github.com/manticoresoftware/manticoresearch/issues/1827), so I've renamed `Book#year` in the tests to `Book#publishing_year`