### PR TITLE
Avoid overwriting existing search methods

### DIFF
--- a/lib/thinking_sphinx/active_record/base.rb
+++ b/lib/thinking_sphinx/active_record/base.rb
@@ -4,6 +4,21 @@ module ThinkingSphinx::ActiveRecord::Base
   extend ActiveSupport::Concern
 
   included do
+    # Avoid method collisions for public Thinking Sphinx methods added to all
+    # ActiveRecord models. The `sphinx_`-prefixed versions will always exist,
+    # and the non-prefixed versions will be added if a method of that name
+    # doesn't already exist.
+    #
+    # If a method is overwritten later by something else, that's also fine - the
+    # prefixed versions will still be there.
+    class_module = ThinkingSphinx::ActiveRecord::Base::ClassMethods
+    class_module.public_instance_methods.each do |method_name|
+      short_method = method_name.to_s.delete_prefix("sphinx_").to_sym
+      next if methods.include?(short_method)
+
+      define_singleton_method(short_method, method(method_name))
+    end
+
     if ActiveRecord::VERSION::STRING.to_i >= 5
       [
         ::ActiveRecord::Reflection::HasManyReflection,
@@ -25,19 +40,19 @@ module ThinkingSphinx::ActiveRecord::Base
   end
 
   module ClassMethods
-    def facets(query = nil, options = {})
+    def sphinx_facets(query = nil, options = {})
       merge_search ThinkingSphinx.facets, query, options
     end
 
-    def search(query = nil, options = {})
+    def sphinx_search(query = nil, options = {})
       merge_search ThinkingSphinx.search, query, options
     end
 
-    def search_count(query = nil, options = {})
+    def sphinx_search_count(query = nil, options = {})
       search_for_ids(query, options).total_entries
     end
 
-    def search_for_ids(query = nil, options = {})
+    def sphinx_search_for_ids(query = nil, options = {})
       ThinkingSphinx::Search::Merger.new(
         search(query, options)
       ).merge! nil, :ids_only => true

--- a/spec/acceptance/searching_within_a_model_spec.rb
+++ b/spec/acceptance/searching_within_a_model_spec.rb
@@ -92,6 +92,13 @@ describe 'Searching within a model', :live => true do
     expect(Album.search(:indices => ['album_real_core']).first).
       to eq(album)
   end
+
+  it "is available via a sphinx-prefixed method" do
+    article = Article.create! :title => 'Pancakes'
+    index
+
+    expect(Article.sphinx_search.first).to eq(article)
+  end
 end
 
 describe 'Searching within a model with a realtime index', :live => true do


### PR DESCRIPTION
This approach will always add the following methods to ActiveRecord::Base:

* `sphinx_search`
* `sphinx_search_for_ids`
* `sphinx_search_count`
* `sphinx_facets`

And then, if there aren't methods already existing without the `sphinx_` prefix, they're also added:

* `search`
* `search_for_ids`
* `search_count`
* `facets`

This does not remove the possibility that something invoked _after_ Thinking Sphinx will overwrite the `search` method, etc - but at least the `sphinx_`-prefixed versions will always be available.

This addresses #1264 and is an evolution of #1241.